### PR TITLE
Paginate the blog.

### DIFF
--- a/app/views/welcome/blog.html.erb
+++ b/app/views/welcome/blog.html.erb
@@ -85,7 +85,7 @@
         
       </ol>
 
-      <%#= will_paginate @entries %>
+      <%= will_paginate @entries %>
       <h3><a href="https://www.tumblr.com/blog/heatseeknyc" class="round-corners button more-button">More</a></h3>
     </div>
   </div>


### PR DESCRIPTION
### Description

This request adds pagination to the [blog](http://heatseeknyc.com/blog). It also makes all posts from the Tumblr available on the Heat Seek website, and reduces the posts fetched from the latest 20 to the posts that will actually be displayed.

The implementation involves a somewhat hack-y definition of methods on the array of posts. This fools `will_paginate` into accepting an array. It's not the prettiest, but it is commonly used and robust.

I went with a page size of 4 based on the commented code that was already there. This can easily be altered.
### Further Development

I don't know what sort of caching you guys have set up, but these blog pages should definitely be cached aggressively. Without caching, each page load has to wait for a call to the Tumblr API.
