### PR TITLE
Update CSS issue breaking tabs on /resources

### DIFF
--- a/app/assets/stylesheets/resources.css.scss
+++ b/app/assets/stylesheets/resources.css.scss
@@ -141,20 +141,8 @@
   }
 
 
-  .resources-manhattan {
-    display:none;  
-  }
-
-  .resources-bronx {
-    display:none;  
-  }
-
-  .resources-queens {
-    display:none;  
-  }
-
-  .resources-statenisland {
-    display:none;  
+  .resources-manhattan, .resources-bronx, .resources-brooklyn, .resources-queens, .resources-statenisland {
+    display:none;
   }
 
   /* MailChimp Form Embed Code - Classic - 08/17/2011 */


### PR DESCRIPTION
Fixes minor issue: if you visit http://heatseeknyc.com/resources , you will see Carroll Gardens listed twice. If you click Queens, you will see both "We don't know any Queens-specific organizations at this time." and Carroll Gardens again. The link keeps sticking around.

This is happening because .resources-brooklyn has missing CSS display: none. Its section will show up until you select Brooklyn and then select another borough.

This pull request fixes the problem
