### PR TITLE
Failed attempt to get an integration test going for the twine scraper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ group :test, :development do
   gem 'spork-rails'
   gem 'sqlite3'
   gem 'travis'
+  gem 'vcr'
+  gem 'webmock'
 end
 
 group :production do 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
     devise (3.2.4)
@@ -255,6 +257,7 @@ GEM
     rubyzip (1.1.6)
     rvm-capistrano (1.5.3)
       capistrano (~> 2.15.4)
+    safe_yaml (1.0.3)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -331,8 +334,12 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    vcr (2.9.3)
     warden (1.2.3)
       rack (>= 1.0)
+    webmock (1.20.4)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     websocket (1.1.4)
     websocket-driver (0.3.4)
     websocket-native (1.0.0)
@@ -397,6 +404,8 @@ DEPENDENCIES
   tumblr_client
   tzinfo
   uglifier (>= 1.3.0)
+  vcr
+  webmock
   will_paginate
   wunderground
   yajl-ruby

--- a/app/models/scrape_driver.rb
+++ b/app/models/scrape_driver.rb
@@ -6,7 +6,11 @@ class ScrapeDriver < DelegateClass(Capybara::Session)
 
   def initialize()
     Capybara.register_driver :chrome_like do |app|  
-      Capybara::Poltergeist::Driver.new(app).tap do |driver|
+      Capybara::Poltergeist::Driver.new(app, 
+                                        phantomjs_options: ["--proxy=localhost:9999", 
+                                                            "--ignore-ssl-errors=true"],
+                                        timeout: 180,
+                                        js_errors: false).tap do |driver|
         driver.add_header("User-Agent", CHROME_AGENT)
       end
     end

--- a/spec/models/twine_spec.rb
+++ b/spec/models/twine_spec.rb
@@ -9,7 +9,20 @@ describe Twine do
     expect(twine1.readings.count).to eq 2
   end
 
-  # describe "#get_reading" do
+  describe "#get_reading" do
+    it "scrapes reading from twine.cc" do
+      expect(Reading.count).to eql 0
+      ENV["WUNDERGROUND_API_KEY"] = 'd48122149ff66bca'
+      twine = Twine.create(user: create(:user), name: 'sandbox', email: 'fake@gmail.com')
+      VCR.use_cassette('wunderground') do
+        reading = twine.get_reading
+      end
+      expect(Reading.count).to eql 1
+      expect(Reading.first.temp).to_not eql nil
+      expect(Reading.first.outdoor_temp).to_not eql nil
+      expect(Reading.first.twine_id).to eql twine.id
+    end
+  end
   #   it "makes a new reading" do
   #     twine_with_reading = create(:twine, email: "wm.jeffries+1@gmail.com")
   #     reading1 = twine_with_reading.get_reading

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ Spork.prefork do
   require 'rspec/rails'
   require 'rspec/autorun'
   require 'capybara/rails'
+  require_relative 'support/vcr'
   require "rails/application"
   Spork.trap_method(Rails::Application, :reload_routes!)
   
@@ -30,7 +31,7 @@ Spork.prefork do
 
   # Requires supporting ruby files with custom matchers and macros, etc,
   # in spec/support/ and its subdirectories.
-  Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+  # Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
   # Checks for pending migrations before tests are run.
   # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,8 @@
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/fixtures/vcr'
+  c.hook_into :webmock
+  c.default_cassette_options = { serialize_with: :json, record: :once }
+  c.debug_logger = File.open(Rails.root.join('log', 'vcr.log'), 'a')
+end

--- a/spec/support/vcr_proxy.rb
+++ b/spec/support/vcr_proxy.rb
@@ -1,0 +1,126 @@
+require 'net/http'
+require 'webrick'
+require 'webrick/https'
+require 'webrick/httpproxy'
+require 'vcr'
+require 'pry'
+require 'webmock'
+# require 'debugger'
+
+# enable modifications to unparsed_uri
+class WEBrick::HTTPRequest
+  def unparsed_uri=(str)
+    @unparsed_uri = str
+  end
+end
+
+class VCRProxy < WEBrick::HTTPProxyServer
+
+  def initialize(options)
+    super(options)
+    @mitm_port = options[:MITMPort] || 12322
+  end
+
+  # starts the MITM server
+  def start_ssl_mitm(host, port)
+    # WORKAROUND for "adress is already in use", just increase
+    # the port number and kill the old webrick
+    @mitm_port += 1
+    @mitm_server.stop if @mitm_server
+    @mitm_thread.kill if @mitm_thread
+
+    @mitm_server = WEBrick::HTTPServer.new(:Port => @mitm_port,
+    :SSLEnable => true,
+    :SSLVerifyClient => ::OpenSSL::SSL::VERIFY_NONE,
+    :SSLCertName => [["C", "US"], ["O", host], ["CN", host] ])
+
+    @mitm_server.mount_proc('/') do |req,res|
+      method, url, version = req.request_line.split(" ")
+
+      remote_request = case method.upcase
+      when 'GET'
+        Net::HTTP::Get.new(req.unparsed_uri)
+      when 'POST'
+        Net::HTTP::Post.new(req.unparsed_uri)
+      when 'PUT'
+        Net::HTTP::Put.new(req.unparsed_uri)
+      when 'DELETE'
+        Net::HTTP::Delete.new(req.unparsed_uri)
+      when 'HEAD'
+        Net::HTTP::Head.new(req.unparsed_uri)
+      when 'OPTIONS'
+        Net::HTTP::Options.new(req.unparsed_uri)
+      else
+        puts "HTTP method '#{method}' not supported!"
+      end
+
+      remote_request.body = req.body
+      remote_request.body = req.body
+      remote_request.initialize_http_header(transform_header(req.header))
+
+      uri = req.request_uri
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+      remote_response = http.request(remote_request)
+
+      remote_response.code
+      res.body = remote_response.body
+      res.status = remote_response.code
+
+      remote_response.header.each do |k|
+        res.header[k] = remote_response.header[k]
+      end
+    end
+
+    @mitm_thread = Thread.new { @mitm_server.start }
+  end
+
+  # transforms the webrick header format into the ruby net http format
+  # webrick:  {"agent"=>["blabla"]}
+  # net http: {"agent"=>"blabla"}
+  def transform_header header
+    h = {}
+    header.each do |key, value|
+      if value.class == Array
+        h[key] = value.first
+      else
+        h[key] = value
+      end
+    end
+    h
+  end
+
+  # the proxy tries to just forward SSL connections with a "CONNECT"
+  # catch that forwarding, and call ssl_mitm
+  def do_CONNECT(req, res)
+    host, port = req.unparsed_uri.split(":")
+    port = 443 unless port
+    start_ssl_mitm(host, port)
+    req.unparsed_uri = "127.0.0.1:#{@mitm_port}"
+    super req, res
+  end
+
+  def service(req, res)
+    VCR.use_cassette("twine.cc#{Thread.list.count}", preserve_exact_body_bytes: true) do
+      super(req, res)
+    end
+  end
+end
+
+VCR.configure do |c|
+  c.hook_into :webmock
+  c.cassette_library_dir = 'spec/fixtures/vcr'
+  c.default_cassette_options = { serialize_with: :json, record: :all }
+  c.ignore_localhost = true
+  c.ignore_hosts "127.0.0.1", "api.intercom.io", "ssl.google-analytics.com"
+  c.ignore_request do |request|
+    URI(request.uri).path =~ %r{png|css|js|woff}
+  end
+  c.debug_logger = File.open('log/vcr.log', 'a')
+end
+
+server = VCRProxy.new(:Port => 9999)
+trap("INT"){ server.shutdown }
+server.start


### PR DESCRIPTION
Records some of the interactions with twine.cc (but not all) through a proxy server. Records wunderground requests fine. Test passed a few times, but most of the time it didn't, so it's unreliable. Looks like it's due to the proxy server using threads, while vcr isn't threadsafe. 

PR just for reference in issue #5, in case somebody has any other ideas on how to get this to work.