### PR TITLE
Set up SendGrid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,15 @@
 Twinenyc::Application.configure do
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    domain: ENV['SENDGRID_DOMAIN'],
+    user_name: ENV["SENDGRID_USERNAME"],
+    password: ENV["SENDGRID_PASSWORD"],
+    address: "smtp.sendgrid.net",
+    port: 587,
+    authentication: "plain",
+    enable_starttls_auto: true
+  }
+
   config.action_mailer.default_url_options = { :host => 'heatseeknyc.com' }
   GA.tracker = "UA-53209413-1"
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,7 +15,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'info@heatseeknyc.com'
+  config.mailer_sender = 'no-reply@heatseeknyc.com'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Set up SendGrid so we can use it for transactional email like password resets. We have a 45 day free trial and hopefully can get free or reduced rates after that for being a non-profit, open source, and an incubee of Blue Ridge Labs. If not, we might want to switch to Mandrill. They're significantly cheaper and transactional mail providers seem fairly easy to swap out (knock on wood).