### PR TITLE
Improve caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,10 @@ gem 'stripe'
 gem 'psych', '= 2.0.5'
 
 group :test do
+  gem 'memory_test_fix'
+  gem 'timecop'
   gem 'vcr'
   gem 'webmock'
-  gem 'memory_test_fix'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,6 +329,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
+    timecop (0.8.0)
     timers (4.0.1)
       hitimes
     tins (1.3.3)
@@ -436,6 +437,7 @@ DEPENDENCIES
   spring
   sqlite3
   stripe
+  timecop
   travis
   tumblr_client
   tzinfo

--- a/app/services/weather_man.rb
+++ b/app/services/weather_man.rb
@@ -3,7 +3,7 @@ class WeatherMan
 
   def self.key_for(zip_code, datetime)
     format = '%Y-%m-%d'
-    format += 'H%H' if datetime.today?
+    format += 'H%H' if datetime.to_date == Date.today
 
     "outdoor_temp_for_#{zip_code}_on_#{datetime.strftime(format)}"
   end

--- a/app/services/weather_man.rb
+++ b/app/services/weather_man.rb
@@ -1,29 +1,34 @@
 class WeatherMan
   @w_api = Wunderground.new(ENV["WUNDERGROUND_API_KEY"])
 
+  def self.key_for(zip_code, datetime)
+    format = '%Y-%m-%d'
+    format += 'H%H' if datetime.today?
+
+    "outdoor_temp_for_#{zip_code}_on_#{datetime.strftime(format)}"
+  end
+
   def self.current_outdoor_temp(zip_code, throttle = 9)
     return nil if !zip_code
-    key = "outdoor_temp_for_#{zip_code}_at_#{Time.now.strftime '%Y-%m-%dT%H'}"
-    Rails.cache.fetch(key, :expires_in => 1.hour) do
+    Rails.cache.fetch(key_for(zip_code, DateTime.now), :expires_in => 1.hour) do
       sleep throttle
       json_object = @w_api.conditions_for(zip_code)
       json_object["current_observation"]["temp_f"]
     end
   end
 
-  def self.outdoor_temp_for(time, zip_code, throttle = nil)
+  def self.outdoor_temp_for(datetime, zip_code, throttle = nil)
     raise ArgumentError if !zip_code
 
     throttle ||= 9
-    key = "outdoor_temp_for_#{zip_code}_at_#{time.strftime '%Y-%m-%dT%H'}"
-    Rails.cache.fetch(key, :expires_in => 1.day) do
+    Rails.cache.fetch(key_for(zip_code, datetime), :expires_in => 1.hour) do
       sleep throttle
-      observationHash = @w_api.history_for(time, zip_code)
+      observationHash = @w_api.history_for(datetime, zip_code)
 
       if observationHash
         observations = observationHash['history']['observations']
         observations.each do |o|
-          if o['date']['hour'].to_i == time.hour.to_i
+          if o['date']['hour'].to_i == datetime.hour.to_i
             return o['tempi'].to_i
           end
         end

--- a/spec/services/weather_man_spec.rb
+++ b/spec/services/weather_man_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
 describe WeatherMan do
-  before do
-    Timecop.travel('March 1, 2015')
-  end
-
-  after do
-    Timecop.return
-  end
-
   describe ".key_for" do
     it "returns a key for a given zip code and datetime" do
       key = WeatherMan.key_for(10001, DateTime.parse('January 1, 2015'))

--- a/spec/services/weather_man_spec.rb
+++ b/spec/services/weather_man_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 
 describe WeatherMan do
+  describe ".key_for" do
+    it "returns a key for a given zip code and datetime" do
+      key = WeatherMan.key_for(10001, DateTime.parse('January 1, 2016'))
+      expect(key).to eq "outdoor_temp_for_10001_on_2016-01-01"
+    end
+
+    it "includes the hour if datetime is today" do
+      key = WeatherMan.key_for(10001, DateTime.now)
+      expect(key).to include "H#{DateTime.now.hour}"
+    end
+  end
+
   describe ".current_outdoor_temp" do
     it "returns current outdoor temperature from Wunderground API" do
       VCR.use_cassette('wunderground') do

--- a/spec/services/weather_man_spec.rb
+++ b/spec/services/weather_man_spec.rb
@@ -1,15 +1,24 @@
 require 'spec_helper'
 
 describe WeatherMan do
+  before do
+    Timecop.travel('March 1, 2015')
+  end
+
+  after do
+    Timecop.return
+  end
+
   describe ".key_for" do
     it "returns a key for a given zip code and datetime" do
-      key = WeatherMan.key_for(10001, DateTime.parse('January 1, 2016'))
-      expect(key).to eq "outdoor_temp_for_10001_on_2016-01-01"
+      key = WeatherMan.key_for(10001, DateTime.parse('January 1, 2015'))
+      expect(key).to eq "outdoor_temp_for_10001_on_2015-01-01"
     end
 
     it "includes the hour if datetime is today" do
-      key = WeatherMan.key_for(10001, DateTime.now)
-      expect(key).to include "H#{DateTime.now.hour}"
+      datetime = DateTime.now
+      key = WeatherMan.key_for(10001, datetime)
+      expect(key).to eq "outdoor_temp_for_10001_on_2015-03-01H00"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,10 @@ Coveralls.wear!
 require 'rubygems'
 require 'spork'
 require 'simplecov'
+require 'timecop'
 
 SimpleCov.start
+Timecop.travel('March 1, 2015')
 
 ENV["RAILS_ENV"] ||= 'test'
 ENV["WUNDERGROUND_API_KEY"] ||= 'd48122149ff66bca'


### PR DESCRIPTION
This new key generation strategy allows for more efficient caching. We only cache at the hourly level when there is a possibility that not all hours of readings have been received yet for that day.