### PR TITLE
Make Users controller edit and update admin only

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,8 @@
 class UsersController < ApplicationController
   include UserControllerHelper
   before_action :authenticate_user!, except: [:demo, :addresses]
+  before_action :authenticate_admin_user!, only: [:edit, :update]
   before_action :load_user, only: [:edit, :update]
-  before_action :validate_admin!, only: [:edit, :update]
-
-  def edit
-  end
 
   def update
     @user.update_without_password(user_params)
@@ -134,10 +131,9 @@ class UsersController < ApplicationController
       ])
     end
 
-    def validate_admin!
-      unless current_user.permissions <= User::PERMISSIONS[:admin]
-        redirect_to root_path
-      end
+    def authenticate_admin_user!
+      return if current_user.permissions == User::PERMISSIONS[:admin]
+      redirect_to root_path
     end
 
     def load_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,20 +1,20 @@
 class UsersController < ApplicationController
   include UserControllerHelper
   before_action :authenticate_user!, except: [:demo, :addresses]
+  before_action :load_user, only: [:edit, :update]
+  before_action :validate_admin!, only: [:edit, :update]
 
   def edit
-    @user = User.find(params[:id])
   end
 
   def update
-    @user = User.find(params[:id])
     @user.update_without_password(user_params)
     @collaboration = current_user.collaborations.where(collaborator_id: @user.id).first
     redirect_to "/users/#{current_user.id}/collaborations/#{@collaboration.id}"
   end
 
   def index
-    if current_user.permissions <= 50
+    if current_user.permissions <= User::PERMISSIONS[:lawyer]
       @users = User.all
     else
       redirect_to current_user
@@ -39,7 +39,7 @@ class UsersController < ApplicationController
   def show
     respond_to do |f|
       f.html do
-        if current_user.permissions <= 50
+        if current_user.permissions <= User::PERMISSIONS[:lawyer]
           render :permissions_show
         else
           render :show
@@ -132,5 +132,15 @@ class UsersController < ApplicationController
         :permissions,
         :twine_name
       ])
+    end
+
+    def validate_admin!
+      unless current_user.permissions <= User::PERMISSIONS[:admin]
+        redirect_to root_path
+      end
+    end
+
+    def load_user
+      @user = User.find(params[:id])
     end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe UsersController do
+  let(:tenant) { create(:user) }
+  let(:lawyer) { create(:user, permissions: User::PERMISSIONS[:lawyer]) }
+  let(:admin) { create(:user, permissions: User::PERMISSIONS[:admin]) }
+
   describe "GET /users/:id/download" do
     let(:pdf_writer) { double('pdf_writer') }
     let(:file) { double('file') }
@@ -26,6 +30,53 @@ describe UsersController do
                               with(file, filename: pdf_writer.filename, type: pdf_writer.content_type).
                               and_return{controller.render :nothing => true}
       get :download_pdf, id: 1                            
+    end
+  end
+
+  describe "GET /users/:id/edit" do
+    it "should render the edit view for an admin user" do
+      sign_in admin
+      get :edit, id: tenant
+
+      expect(response.status).to eq(200)
+      expect(response).to render_template("edit")
+    end
+
+    it "should redirect a non-admin user to the root path" do
+      sign_in tenant
+      get :edit, id: tenant
+
+      expect(response).to redirect_to(root_path)
+
+      sign_in lawyer
+      get :edit, id: tenant
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "GET /users/:id/update" do
+    let(:params) { { id: tenant, user: { first_name: "Updated" } } }
+
+    it "should update the resource if the request comes from an admin user" do
+      admin.collaborations.create(collaborator: tenant)
+      sign_in admin
+      put :update, params
+
+      expect(response.status).to eq(302)
+      expect(tenant.reload.first_name).to eq("Updated")
+    end
+
+    it "should redirect a request from a non-admin user" do
+      sign_in tenant
+      put :update, params
+
+      expect(response).to redirect_to(root_path)
+
+      sign_in lawyer
+      put :update, params
+
+      expect(response).to redirect_to(root_path)
     end
   end
 end


### PR DESCRIPTION
@williamcodes Fixes the bug I mentioned at the last meeting.

Updating the permissions logic in the controller made me think that the permission logic should be moved to the Users model so the controller could simply check something like
```ruby
if current_user.is_admin?
...
if current_user.is_admin? || current_user.is_lawyer?
```
I think there should be a new issue to refactor those permission sets.

