### PR TITLE
Csv exporter for readings

### DIFF
--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -2,7 +2,7 @@ class ReadingsController < ApplicationController
   protect_from_forgery except: :create
 
   def index
-    if current_user && current_user.permissions == User::PERMISSIONS[:admin]
+    if current_user && current_user.permissions <= User::PERMISSIONS[:team_member]
       respond_to do |format|
         format.csv do
           filter_params = params[:readings] || {}

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -1,6 +1,24 @@
 class ReadingsController < ApplicationController
   protect_from_forgery except: :create
 
+  def index
+    if current_user && current_user.permissions == User::PERMISSIONS[:admin]
+      respond_to do |format|
+        format.csv do
+          filter_params = params[:readings] || {}
+          exporter = ReadingsExporter.new(filter_params)
+          send_data(
+            exporter.to_csv,
+            type: "text/csv; charset=utf-8; header=present",
+            filename: "sensor_readings.csv"
+          )
+        end
+      end
+    else
+      render nothing: true, status: :unauthorized
+    end
+  end
+
   def create
     render_error and return if verifier.failing?
     handle_dupe and return if verifier.dupe?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -147,7 +147,7 @@ class UsersController < ApplicationController
     end
 
     def authenticate_admin_user!
-      return if current_user.permissions == User::PERMISSIONS[:admin]
+      return if current_user.permissions <= User::PERMISSIONS[:admin]
       redirect_to root_path
     end
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -37,12 +37,10 @@ class WelcomeController < ApplicationController
     # Cache Tumblr data hourly, on the hour.
     Rails.cache.fetch("blog_page_#{page}_#{Time.now.strftime('%Y%m%d%H')}") do
       Rails.logger.info("\n FETCHING FROM TUMBLR \n")
-      client = Tumblr::Client.new({
-                                    :consumer_key => ENV['TUMBLR_CONSUMER_KEY'],
-                                    :consumer_secret => ENV['TUMBLR_CONSUMER_SECRET'],
-                                    :oauth_token => ENV['TUMBLR_OAUTH_TOKEN'],
-                                    :oauth_token_secret => ENV['TUMBLR_OAUTH_TOKEN_SECRET']
-                                  })
+      client = Tumblr::Client.new(:consumer_key => ENV['TUMBLR_CONSUMER_KEY'],
+                                  :consumer_secret => ENV['TUMBLR_CONSUMER_SECRET'],
+                                  :oauth_token => ENV['TUMBLR_OAUTH_TOKEN'],
+                                  :oauth_token_secret => ENV['TUMBLR_OAUTH_TOKEN_SECRET'])
 
       result = client.posts(
         'heatseeknyc.tumblr.com',
@@ -51,7 +49,7 @@ class WelcomeController < ApplicationController
       )
 
       {
-        :posts => result['posts'].sort{|a,b| b['date'] <=> a['date']},
+        :posts => result['posts'].sort{|a, b| b['date'] <=> a['date']},
         :total_pages => result["total_posts"].fdiv(BLOG_PAGE_SIZE).ceil
       }
     end

--- a/app/models/readings_exporter.rb
+++ b/app/models/readings_exporter.rb
@@ -2,9 +2,7 @@ require "csv"
 
 class ReadingsExporter
   HEADERS = [
-    "date",
-    "time",
-    "time_zone",
+    "timestamp",
     "temp_inside",
     "temp_outside",
     "in_violation",
@@ -39,9 +37,7 @@ class ReadingsExporter
   def format_values(reading)
     [].tap do |values|
       values.push(
-        reading.created_at.strftime("%Y-%m-%d"),
-        reading.created_at.strftime("%H:%M:%S"),
-        reading.created_at.strftime("%z"),
+        reading.created_at,
         reading.temp,
         reading.outdoor_temp,
         reading.violation,

--- a/app/models/readings_exporter.rb
+++ b/app/models/readings_exporter.rb
@@ -1,17 +1,17 @@
 require "csv"
 
 class ReadingsExporter
-  HEADERS = %w{
-    date
-    time
-    time_zone
-    temp_inside
-    temp_outside
-    in_violation
-    sensor_id
-    address
-    zip_code
-  }
+  HEADERS = [
+    "date",
+    "time",
+    "time_zone",
+    "temp_inside",
+    "temp_outside",
+    "in_violation",
+    "sensor_id",
+    "address",
+    "zip_code"
+  ].freeze
 
   def initialize(params = {})
     @filter = params[:filter]
@@ -28,12 +28,8 @@ class ReadingsExporter
 
   def collection
     readings = Reading
-    if @start_time
-      readings = readings.where("readings.created_at >= ?", @start_time)
-    end
-    if @end_time
-      readings = readings.where("readings.created_at < ?", @end_time)
-    end
+    readings = readings.where("readings.created_at >= ?", @start_time) if @start_time
+    readings = readings.where("readings.created_at < ?", @end_time) if @end_time
     readings = readings.where(@filter) if @filter
     readings.includes(:user).order(:created_at)
   end
@@ -49,7 +45,7 @@ class ReadingsExporter
         reading.temp,
         reading.outdoor_temp,
         reading.violation,
-        reading.sensor_id,
+        reading.sensor_id
       )
 
       if reading.user

--- a/app/models/readings_exporter.rb
+++ b/app/models/readings_exporter.rb
@@ -1,0 +1,56 @@
+require "csv"
+
+class ReadingsExporter
+  HEADERS = %w{
+    date
+    time
+    time_zone
+    temp_inside
+    temp_outside
+    in_violation
+    sensor_id
+    address
+    zip_code
+  }
+
+  def initialize(params = {})
+    @filter = params[:filter]
+    @start_time = params[:start_time]
+    @end_time = params[:end_time]
+  end
+
+  def to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << HEADERS
+      collection.each { |reading| csv << row_values(reading) }
+    end
+  end
+
+  def collection
+    readings = Reading
+    if @start_time
+      readings = readings.where("readings.created_at >= ?", @start_time)
+    end
+    if @end_time
+      readings = readings.where("readings.created_at < ?", @end_time)
+    end
+    readings = readings.where(@filter) if @filter
+    readings.joins(:user).order(:created_at)
+  end
+
+  private
+
+  def row_values(reading)
+    [
+      reading.created_at.strftime("%Y-%m-%d"),
+      reading.created_at.strftime("%H:%M:%S"),
+      reading.created_at.strftime("%z"),
+      reading.temp,
+      reading.outdoor_temp,
+      reading.violation,
+      reading.sensor_id,
+      reading.user.address,
+      reading.user.zip_code
+    ]
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,8 @@ class User < ActiveRecord::Base
   include Regulatable::InstanceMethods
 
   PERMISSIONS = {
+    super_user: 0,
+    team_member: 10,
     admin: 25,
     lawyer: 50,
     user: 100

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Twinenyc::Application.routes.draw do
     end
   end
 
-  post 'readings' => 'readings#create'
+  resources :readings, only: [:index, :create]
 
   get 'addresses' => 'users#addresses'
   get 'users/:id/download' => 'users#download_pdf', as: :pdf_download

--- a/spec/controllers/readings_controller_spec.rb
+++ b/spec/controllers/readings_controller_spec.rb
@@ -1,33 +1,39 @@
 require 'spec_helper'
 
 describe ReadingsController do
-  let(:tenant) { create(:user) }
-  let(:admin) { create(:user, permissions: User::PERMISSIONS[:admin]) }
-
   describe "GET /readings/index" do
     let(:exporter) { double("readings_exporter") }
 
     before do
-      sign_in admin
       allow(exporter).to receive(:to_csv)
     end
 
-    it "sends data in csv format" do
-      expect(controller)
-        .to receive(:send_data)
-        .with("#{ReadingsExporter::HEADERS.join(',')}\n",
-              filename: "sensor_readings.csv",
-              type: "text/csv; charset=utf-8; header=present")
-        .and_return { controller.render nothing: true }
+    it "returns a 401 error for unauthorized users" do
+      sign_in create(:advocate)
       get :index, format: :csv
+      expect(response.status).to eq(401)
     end
 
-    it "instantiates a ReadingsExporter using the provided query parameters" do
-      expect(ReadingsExporter)
-        .to receive(:new)
-        .with("filter" => { "user_id" => 1 })
-        .and_return { exporter }
-      get :index, format: :csv, readings: { filter: { user_id: 1 } }
+    context "authorized user sign in" do
+      before { sign_in create(:team_member) }
+
+      it "sends data in csv format" do
+        expect(controller)
+          .to receive(:send_data)
+          .with("#{ReadingsExporter::HEADERS.join(',')}\n",
+                filename: "sensor_readings.csv",
+                type: "text/csv; charset=utf-8; header=present")
+          .and_return { controller.render nothing: true }
+        get :index, format: :csv
+      end
+
+      it "instantiates a ReadingsExporter using the provided query parameters" do
+        expect(ReadingsExporter)
+          .to receive(:new)
+          .with("filter" => { "user_id" => 1 })
+          .and_return { exporter }
+        get :index, format: :csv, readings: { filter: { user_id: 1 } }
+      end
     end
   end
 end

--- a/spec/controllers/readings_controller_spec.rb
+++ b/spec/controllers/readings_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe ReadingsController do
+  let(:tenant) { create(:user) }
+  let(:admin) { create(:user, permissions: User::PERMISSIONS[:admin]) }
+
+  describe "GET /readings/index" do
+    let(:exporter) { double("readings_exporter") }
+
+    before do
+      sign_in admin
+      allow(exporter).to receive(:to_csv)
+    end
+
+    it "sends data in csv format" do
+      expect(controller)
+        .to receive(:send_data)
+        .with("#{ReadingsExporter::HEADERS.join(',')}\n",
+              filename: "sensor_readings.csv",
+              type: "text/csv; charset=utf-8; header=present")
+        .and_return { controller.render nothing: true }
+      get :index, format: :csv
+    end
+
+    it "instantiates a ReadingsExporter using the provided query parameters" do
+      expect(ReadingsExporter)
+        .to receive(:new)
+        .with({ "filter" => { "user_id" => 1 } })
+        .and_return { exporter }
+      get :index, format: :csv, readings: { filter: { user_id: 1 } }
+    end
+  end
+end

--- a/spec/controllers/readings_controller_spec.rb
+++ b/spec/controllers/readings_controller_spec.rb
@@ -25,7 +25,7 @@ describe ReadingsController do
     it "instantiates a ReadingsExporter using the provided query parameters" do
       expect(ReadingsExporter)
         .to receive(:new)
-        .with({ "filter" => { "user_id" => 1 } })
+        .with("filter" => { "user_id" => 1 })
         .and_return { exporter }
       get :index, format: :csv, readings: { filter: { user_id: 1 } }
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,8 +12,12 @@ FactoryGirl.define do
     password_confirmation { |u| u.password }
     email { |u| "#{u.first_name}@example.com" }
 
-    trait :admin do
+    trait :team_member do
       permissions 10
+    end
+
+    trait :admin do
+      permissions 25
     end
 
     trait :advocate do
@@ -24,6 +28,7 @@ FactoryGirl.define do
       permissions 100
     end
 
+    factory :team_member, traits: [:team_member]
     factory :admin, traits: [:admin]
     factory :advocate, traits: [:advocate]
     factory :tenant, traits: [:tenant]

--- a/spec/features/managing_articles_spec.rb
+++ b/spec/features/managing_articles_spec.rb
@@ -8,14 +8,14 @@ feature "Managing articles" do
     article2 = FactoryGirl.create(:article, published_date: 2.days.ago)
     article3 = FactoryGirl.create(:article, published_date: 1.day.ago)
 
-    login_as_admin
+    login_as_team_member
     click_link "Articles"
 
     expect(page).to have_content "Listing articles"
   end
 
   scenario "Creating" do
-    login_as_admin
+    login_as_team_member
     click_link "Articles"
     click_link "New Article"
 

--- a/spec/models/readings_exporter_spec.rb
+++ b/spec/models/readings_exporter_spec.rb
@@ -1,15 +1,17 @@
 require "spec_helper"
 
 describe ReadingsExporter do
-  let(:user) { create(:user) }
+  let(:user_1) { create(:user) }
+  let(:user_2) { create(:user) }
+  let(:user_3) { create(:user) }
   let!(:reading_1) do
-    create(:reading, temp: 50, created_at: 1.week.ago, user: user)
+    create(:reading, temp: 50, created_at: 1.week.ago, user: user_1)
   end
   let!(:reading_2) do
-    create(:reading, temp: 55, created_at: 3.days.ago, user: user)
+    create(:reading, temp: 55, created_at: 3.days.ago, user: user_2)
   end
   let!(:reading_3) do
-    create(:reading, temp: 60, created_at: 1.day.ago, user: user)
+    create(:reading, temp: 60, created_at: 1.day.ago, user: user_3)
   end
 
   it "transforms readings into a csv format" do
@@ -19,10 +21,16 @@ describe ReadingsExporter do
   end
 
   describe "building a collection of readings" do
-    it "filters by Reading attributes" do
-      exporter = ReadingsExporter.new(filter: { user_id: user.id,
+    it "filters by multiple attributes on the Reading model" do
+      exporter = ReadingsExporter.new(filter: { user_id: user_1.id,
                                                 temp: reading_1.temp })
       expect(exporter.collection).to eq([reading_1])
+    end
+
+    it "filters by a collection of user ids" do
+      exporter = ReadingsExporter.new(filter: { user_id: [user_1.id,
+                                                          user_2.id] })
+      expect(exporter.collection).to eq([reading_1, reading_2])
     end
 
     it "filters by a start time" do

--- a/spec/models/readings_exporter_spec.rb
+++ b/spec/models/readings_exporter_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+describe ReadingsExporter do
+  let(:user) { create(:user) }
+  let!(:reading_1) do
+    create(:reading, temp: 50, created_at: 1.week.ago, user: user)
+  end
+  let!(:reading_2) do
+    create(:reading, temp: 55, created_at: 3.days.ago, user: user)
+  end
+  let!(:reading_3) do
+    create(:reading, temp: 60, created_at: 1.day.ago, user: user)
+  end
+
+  it "transforms readings into a csv format" do
+    exporter = ReadingsExporter.new
+    csv = exporter.to_csv
+    expect(csv.lines.count).to eq(4)
+  end
+
+  describe "building a collection of readings" do
+    it "filters by Reading attributes" do
+      exporter = ReadingsExporter.new(filter: { user_id: user.id,
+                                                temp: reading_1.temp })
+      expect(exporter.collection).to eq([reading_1])
+    end
+
+    it "filters by a start time" do
+      exporter = ReadingsExporter.new(start_time: 4.days.ago)
+      expect(exporter.collection).to eq([reading_2, reading_3])
+    end
+
+    it "filters by an end time" do
+      exporter = ReadingsExporter.new(start_time: 6.days.ago)
+      expect(exporter.collection).to eq([reading_2, reading_3])
+    end
+
+    it "filters by a time range" do
+      exporter = ReadingsExporter.new(start_time: 8.days.ago,
+                                      end_time: 6.days.ago)
+      expect(exporter.collection).to eq([reading_1])
+    end
+  end
+end

--- a/spec/models/readings_exporter_spec.rb
+++ b/spec/models/readings_exporter_spec.rb
@@ -19,9 +19,7 @@ describe ReadingsExporter do
     csv = exporter.to_csv
     expect(csv.lines.count).to eq(4)
     expect(CSV.parse(csv, headers: true).first.to_s.chomp).to eq(
-      [reading_1.created_at.strftime("%Y-%m-%d"),
-       reading_1.created_at.strftime("%H:%M:%S"),
-       reading_1.created_at.strftime("%z"),
+      [reading_1.created_at,
        reading_1.temp,
        reading_1.outdoor_temp,
        reading_1.violation,

--- a/spec/models/readings_exporter_spec.rb
+++ b/spec/models/readings_exporter_spec.rb
@@ -19,7 +19,16 @@ describe ReadingsExporter do
     csv = exporter.to_csv
     expect(csv.lines.count).to eq(4)
     expect(CSV.parse(csv, headers: true).first.to_s.chomp).to eq(
-      "2015-02-22,00:00:03,-0500,50,40,false,,11 Broadway,10004"
+      [reading_1.created_at.strftime("%Y-%m-%d"),
+       reading_1.created_at.strftime("%H:%M:%S"),
+       reading_1.created_at.strftime("%z"),
+       reading_1.temp,
+       reading_1.outdoor_temp,
+       reading_1.violation,
+       reading_1.sensor_id,
+       reading_1.user.address,
+       reading_1.user.zip_code
+      ].join(",")
     )
   end
 

--- a/spec/models/readings_exporter_spec.rb
+++ b/spec/models/readings_exporter_spec.rb
@@ -23,6 +23,13 @@ describe ReadingsExporter do
     )
   end
 
+  it "can export invalid readings without an associated user" do
+    reading = create(:reading)
+    reading.update_column(:user_id, nil)
+    exporter = ReadingsExporter.new(filter: { user_id: nil} )
+    expect(exporter.to_csv.lines.count).to eq(2)
+  end
+
   describe "building a collection of readings" do
     it "filters by multiple attributes on the Reading model" do
       exporter = ReadingsExporter.new(filter: { user_id: user_1.id,

--- a/spec/models/readings_exporter_spec.rb
+++ b/spec/models/readings_exporter_spec.rb
@@ -35,7 +35,7 @@ describe ReadingsExporter do
   it "can export invalid readings without an associated user" do
     reading = create(:reading)
     reading.update_column(:user_id, nil)
-    exporter = ReadingsExporter.new(filter: { user_id: nil} )
+    exporter = ReadingsExporter.new(filter: { user_id: nil })
     expect(exporter.to_csv.lines.count).to eq(2)
   end
 

--- a/spec/models/readings_exporter_spec.rb
+++ b/spec/models/readings_exporter_spec.rb
@@ -18,6 +18,9 @@ describe ReadingsExporter do
     exporter = ReadingsExporter.new
     csv = exporter.to_csv
     expect(csv.lines.count).to eq(4)
+    expect(CSV.parse(csv, headers: true).first.to_s.chomp).to eq(
+      "2015-02-22,00:00:03,-0500,50,40,false,,11 Broadway,10004"
+    )
   end
 
   describe "building a collection of readings" do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -7,6 +7,10 @@ def login_as_type(type, options = {})
   return user
 end
 
+def login_as_team_member
+  login_as_type(:team_member)
+end
+
 def login_as_admin
   login_as_type(:admin)
 end


### PR DESCRIPTION
@williamcodes 
Preliminary PR for https://github.com/heatseeknyc/heatseeknyc/issues/158

- Adds a ReadingsExporter class that only performs a to_csv conversion (it could be extended to also format for json, xls, or other formats if desired). I expect that this class can be refactored later to handle export of other models as well.
- A preliminary list of columns headers and formatting of those columns -- there may be other fields that should be included or removed (I added time zone, example, but we probably don't need that)
- Added a new /readings/index resource that is admin-only for the time being
- Ability to pass query/filter parameters to narrow down to a specific date range or by specific user/tenant ids.

Remaining work:
- Finalize the columns that should be included and their formatting if applicable
- Identify where the download button(s) should go -- This should probably be done in a follow-on PR that updates the appropriate views. Where would the button go for a bulk download for the data science use case?  Where should it go for the advocate managing multiple tenants?  Where should it be located for downloading data on a single tenant?

Questions that came up:
- While working on this I started thinking that different permission levels may warrant different columns. For example, the advocate/lawyer should probably be allowed to see the user name and address, but would someone using this as a data science set have a more anonymized file generated?  Should there be another permission type for data science or other volunteers?
- Should we ever export readings that have no user_id associated? I don't know if that exits in production database, but the development seed did have records without a user id.

Future ideas:
- Filter by heating season. Maybe heating season start and end dates belong in a database table.