### PR TITLE
Building model

### DIFF
--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,0 +1,8 @@
+class Building < ActiveRecord::Base
+  has_many :tenants, class_name: User.name
+
+  validates_presence_of :street_address, :zip_code
+  validates_format_of :zip_code,
+                      with: /\A\d{5}-\d{4}|\A\d{5}\z/,
+                      message: "should be 12345 or 12345-1234"
+end

--- a/db/migrate/20160525052314_create_buildings.rb
+++ b/db/migrate/20160525052314_create_buildings.rb
@@ -1,0 +1,15 @@
+class CreateBuildings < ActiveRecord::Migration
+  def change
+    create_table :buildings do |t|
+      t.string :property_name
+      t.text :description
+      t.string :street_address
+      t.string :zip_code
+      t.integer :bin
+      t.string :bbl
+      t.timestamps
+    end
+
+    add_reference :users, :building, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160310201839) do
+ActiveRecord::Schema.define(version: 20160525052314) do
 
   create_table "articles", force: true do |t|
     t.string   "title"
@@ -22,6 +22,17 @@ ActiveRecord::Schema.define(version: 20160310201839) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.date     "published_date"
+  end
+
+  create_table "buildings", force: true do |t|
+    t.string   "property_name"
+    t.text     "description"
+    t.string   "street_address"
+    t.string   "zip_code"
+    t.integer  "bin"
+    t.string   "bbl"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "canonical_temperatures", force: true do |t|
@@ -105,8 +116,10 @@ ActiveRecord::Schema.define(version: 20160310201839) do
     t.string   "phone_number"
     t.string   "apartment"
     t.boolean  "dummy"
+    t.integer  "building_id"
   end
 
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  add_index "users", ["building_id"], name: "index_users_on_building_id", using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
 end

--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :building do
+    street_address "11 Broadway"
+    zip_code "10004"
+  end
+end

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -6,7 +6,6 @@ describe Building do
   it "has tenants" do
     2.times { building.tenants << create(:user) }
     expect(building.tenants.count).to eq(2)
-    binding.pry
   end
 
   describe "address validations" do
@@ -45,6 +44,5 @@ describe Building do
       expect(building).to_not be_valid
       expect(building.errors[:zip_code]).to eq(zip_code_error)
     end
-
   end
 end

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+describe Building do
+  let(:building) { create(:building) }
+
+  it "has tenants" do
+    2.times { building.tenants << create(:user) }
+    expect(building.tenants.count).to eq(2)
+    binding.pry
+  end
+
+  describe "address validations" do
+    let(:zip_code_error) { ["should be 12345 or 12345-1234"] }
+
+    it "requires a street address and zip code" do
+      expect(building).to be_valid
+    end
+
+    it "validates the presence of the street address" do
+      building.update_attributes(street_address: nil)
+      expect(building).to_not be_valid
+      expect(building.errors[:street_address]).to eq(["can't be blank"])
+    end
+
+    it "validates the presence of the zip code" do
+      building.update_attributes(zip_code: nil)
+      expect(building).to_not be_valid
+      expect(building.errors[:zip_code]).to include("can't be blank")
+    end
+
+    it "validates the format of a 9-digit zip code" do
+      building.update_attributes(zip_code: "10001-1234")
+      expect(building).to be_valid
+
+      building.update_attributes(zip_code: "100011234")
+      expect(building).to_not be_valid
+      expect(building.errors[:zip_code]).to eq(zip_code_error)
+    end
+
+    it "validates the format of a 5-digit zip code" do
+      building.update_attributes(zip_code: "10001")
+      expect(building).to be_valid
+
+      building.update_attributes(zip_code: "1000")
+      expect(building).to_not be_valid
+      expect(building.errors[:zip_code]).to eq(zip_code_error)
+    end
+
+  end
+end


### PR DESCRIPTION
@williamcodes 
https://github.com/heatseeknyc/heatseeknyc/issues/153
Deploy and run associated migration first. This does not update/change existing data or functionality around the addresses stored in the User model.

Adds the basic associations for Building <-> User
I am the name tenants in the has_many association since I expect we will eventually swap out the User model with Tenant

The zip code validation is copied from the basic one used in the User model. I believe there's a separate issue in the backlog for improving that/fixing the instances where zips are stored as integers instead of strings.