### PR TITLE
Model validations for building uniqueness

### DIFF
--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -5,4 +5,7 @@ class Building < ActiveRecord::Base
   validates_format_of :zip_code,
                       with: /\A\d{5}-\d{4}|\A\d{5}\z/,
                       message: "should be 12345 or 12345-1234"
+  validates :street_address, uniqueness: { scope: :zip_code, case_sensitive: false }
+
+  before_save { |building| building.street_address = building.street_address.downcase }
 end

--- a/db/migrate/20160601190251_add_unique_index_to_buildings.rb
+++ b/db/migrate/20160601190251_add_unique_index_to_buildings.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToBuildings < ActiveRecord::Migration
+  def change
+    add_index :buildings, [:street_address, :zip_code], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160525052314) do
+ActiveRecord::Schema.define(version: 20160601190251) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 20160525052314) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "buildings", ["street_address", "zip_code"], name: "index_buildings_on_street_address_and_zip_code", unique: true, using: :btree
 
   create_table "canonical_temperatures", force: true do |t|
     t.integer  "zip_code"

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -45,4 +45,26 @@ describe Building do
       expect(building.errors[:zip_code]).to eq(zip_code_error)
     end
   end
+
+  describe "address uniqueness" do
+    it "converts street_address to lower case before saving" do
+      building.street_address = "123 New Street"
+      building.save
+      expect(building.reload.street_address).to eq("123 new street")
+    end
+
+    it "validates uniqueness in a case-insensitive manner" do
+      building_dupe = Building.new(street_address: building.street_address.upcase,
+                                   zip_code: building.zip_code)
+      expect(building_dupe).to_not be_valid
+      expect(building_dupe.errors[:street_address])
+        .to eq(["has already been taken"])
+    end
+
+    it "permits the same street address with different zip codes" do
+      building_2 = Building.new(street_address: building.street_address,
+                                zip_code: "99999")
+      expect(building_2).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Model validations to go along with the unique index for the Building model.  A before_save is used here to downcase the street address so it is stored as lower case characters only.

I think it may be a good idea to convert the street_address to citext instead of string, but that makes it Postgres-specific, I believe, which may cause some issues with the SQLite test environment, but I have not verified that yet.