### PR TITLE
Enable Travis CI's caching feature for bundler to reduce build time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - 2.1.3
+cache: bundler
 env:
   global:
   - secure: wMOkyOiC7B9wCoStmW7FvoMqAn7h8GXzt1WOOKQutLIVdoI0dvhrIRViT5ZICvgHIqUoIdRx42AUfXIxC4y+FOatJTmo2GCa4SsctqWLOjX9lQSn1wqaflIfgi5mYoYSKJzJ6KSxIdMQsWA6PLlhSlHLVyKJsINoIADcrxh1Hw0=


### PR DESCRIPTION
@williamcodes Travis CI builds spend a little over 2 minutes running bundle install. Fortunately, Travis has a built-in way of caching that. It invalidates the cache automatically and re-bundles if your Gemfile.lock changes.  You can also clear the cache in the Travis dashboard or CLI if you need to.

https://docs.travis-ci.com/user/caching/