### PR TITLE
Unit (Apartment) model

### DIFF
--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,5 +1,6 @@
 class Building < ActiveRecord::Base
-  has_many :tenants, class_name: User.name
+  has_many :units
+  has_many :tenants, through: :units, class_name: User.name
 
   validates_presence_of :street_address, :zip_code
   validates_format_of :zip_code,

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,0 +1,9 @@
+class Unit < ActiveRecord::Base
+  belongs_to :building
+  has_many :tenants, class_name: User.name
+
+  validates_presence_of :building, :name
+  validates :name, uniqueness: { scope: :building, case_sensitive: false }
+
+  before_save { |unit| unit.name = unit.name.downcase }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ActiveRecord::Base
   has_many :collaborations, dependent: :destroy
   has_many :collaborators, through: :collaborations
 
+  belongs_to :unit
+  delegate :building, to: :unit, allow_nil: true
+
   validates :first_name, :length => { minimum: 2 }
   validates :last_name, :length => { minimum: 2 }
   validate :sensor_codes_string_contains_only_valid_sensors

--- a/db/migrate/20160604175804_create_units.rb
+++ b/db/migrate/20160604175804_create_units.rb
@@ -1,0 +1,16 @@
+class CreateUnits < ActiveRecord::Migration
+  def change
+    create_table :units do |t|
+      t.integer :building_id
+      t.string :name
+      t.integer :floor
+      t.text :description
+      t.timestamps
+    end
+
+    add_index :units, :building_id
+    add_index :units, [:building_id, :name], unique: true
+
+    add_reference :users, :unit, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601195459) do
+ActiveRecord::Schema.define(version: 20160604175804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601190251) do
+ActiveRecord::Schema.define(version: 20160604175804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,18 @@ ActiveRecord::Schema.define(version: 20160601190251) do
     t.string  "email"
   end
 
+  create_table "units", force: true do |t|
+    t.integer  "building_id"
+    t.string   "name"
+    t.integer  "floor"
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "units", ["building_id", "name"], name: "index_units_on_building_id_and_name", unique: true, using: :btree
+  add_index "units", ["building_id"], name: "index_units_on_building_id", using: :btree
+
   create_table "users", force: true do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -122,9 +134,11 @@ ActiveRecord::Schema.define(version: 20160601190251) do
     t.string   "apartment"
     t.boolean  "dummy",                  default: false, null: false
     t.integer  "building_id"
+    t.integer  "unit_id"
   end
 
   add_index "users", ["building_id"], name: "index_users_on_building_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["unit_id"], name: "index_users_on_unit_id", using: :btree
 
 end

--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :building do
-    street_address "11 Broadway"
+    street_address { Faker::Address.street_address }
     zip_code "10004"
   end
 end

--- a/spec/factories/units.rb
+++ b/spec/factories/units.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :unit do
+    name { Faker::Address.secondary_address }
+    association :building, factory: :building
+  end
+end

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -3,9 +3,25 @@ require "spec_helper"
 describe Building do
   let(:building) { create(:building) }
 
-  it "has tenants" do
-    2.times { building.tenants << create(:user) }
-    expect(building.tenants.count).to eq(2)
+  describe "associations" do
+    it "has many units" do
+      new_unit = create(:unit, building: building)
+      another_unit = create(:unit, building: building)
+      building.units << new_unit
+      building.units << another_unit
+      expect(building.units).to eq([new_unit, another_unit])
+    end
+
+    it "has tenants through the Unit model" do
+      user_1 = create(:user)
+      user_2 = create(:user)
+      unit_1 = create(:unit, building: building)
+      unit_2 = create(:unit, building: building)
+      unit_1.tenants << user_1
+      unit_2.tenants << user_2
+
+      expect(building.tenants).to eq([user_1, user_2])
+    end
   end
 
   describe "address validations" do

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe Unit do
+  let(:unit) { create(:unit) }
+
+  describe "validations" do
+    let(:blank_error) { ["can't be blank"] }
+
+    it "validates the presence of a unit name" do
+      invalid_unit = Unit.new(name: nil)
+      expect(invalid_unit).to_not be_valid
+      expect(invalid_unit.errors[:name]).to eq(blank_error)
+    end
+
+    it "validates the presence of a building" do
+      invalid_unit = Unit.new(building: nil)
+      expect(invalid_unit).to_not be_valid
+      expect(invalid_unit.errors[:building]).to eq(blank_error)
+    end
+  end
+
+  describe "associations" do
+    it "belongs to a building" do
+      building = create(:building)
+      unit.update_attributes!(building: building)
+      expect(unit.reload.building).to eq(building)
+    end
+
+    it "has many tenants" do
+      unit.tenants << create(:user)
+      unit.tenants << create(:user)
+      expect(unit.tenants.count).to eq(2)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -135,4 +135,21 @@ describe User do
       expect(permissions_hash[:team_member]).to be_nil
     end
   end
+
+  describe "unit and building associations" do
+    let(:user) { create(:user) }
+
+    it "has a unit association" do
+      unit = create(:unit)
+      unit.tenants << user
+      expect(user.unit).to eq(unit)
+    end
+
+    it "delegates building to the associated unit" do
+      building = create(:building)
+      unit = create(:unit, building: building)
+      unit.tenants << user
+      expect(user.building).to eq(building)
+    end
+  end
 end


### PR DESCRIPTION
@williamcodes 

This branch was built off of the building-controller branch https://github.com/heatseeknyc/heatseeknyc/pull/181
which should be ready for final review and merge.  I'll rebase after that is merged so the diff doesn't look as overwhelming in this PR.

I decided to use the model name Unit instead of Apartment so we wouldn't get a conflict with the existing Apartments field on the User model and also so it's more generic representation of the address part (the Unit Number, Building Unit... the rental could be a condo or co-op, which is technically not an apartment, for example).

I'm not opposed to using Apartment name, but I think we'll need to take the extra step of renaming the existing apartments column in the Users model first.