### PR TITLE
Units controller

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,6 +27,7 @@
 //= require collaboration
 //= require complaint
 //= require kickstarter
+//= require user-forms
 //= require video
 //= require resources
 // 

--- a/app/assets/javascripts/user-forms.js
+++ b/app/assets/javascripts/user-forms.js
@@ -1,0 +1,37 @@
+$(function() {
+  function unitOption(unit) {
+    return '<option value="' + unit.id + '">' + unit.name.toUpperCase() + '</option>'; 
+  }
+
+  function getUnitOptions(buildingId, $unitSelector) {
+    $unitSelector.attr('disabled', true);
+    $unitSelector.children().remove();
+
+    if (buildingId === '')
+    { 
+      return;
+    }
+
+    $.getJSON('/admin/buildings/' + buildingId + '/units', function(data) {
+      $unitSelector.append('<option></option>');
+
+      if (data.results.length !== 0)
+      {
+        $.each(data.results, function() {
+          $unitSelector.append(unitOption(this));
+        });
+      }
+
+      $unitSelector.attr('disabled', false);
+    });
+  }
+
+  $(document).ready(function() {
+    var $buildingSelector = $('#user_building_id');
+    var $unitSelector = $('#user_unit_id');
+
+    $($buildingSelector).change(function() {
+      getUnitOptions($buildingSelector.val(), $unitSelector);
+    });
+  });
+});

--- a/app/assets/stylesheets/forms.css.scss
+++ b/app/assets/stylesheets/forms.css.scss
@@ -41,6 +41,10 @@
       width: 40%;
     }
 
+    &.uppercase-field {
+      text-transform: uppercase;
+    }
+
     &:focus {
       box-shadow: none;
     }

--- a/app/controllers/admin/buildings_controller.rb
+++ b/app/controllers/admin/buildings_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class BuildingsController < AdminController
-    before_action :load_building, only: [:edit, :update]
+    before_action :load_building, only: [:destroy, :edit, :update]
 
     def index
       @buildings = Building.all
@@ -26,6 +26,17 @@ module Admin
         error_flash
         render action: "edit"
       end
+    end
+
+    def destroy
+      flash[:alert] =
+        if @building.destroy
+          "Building deleted."
+        else
+          "Delete failed: #{@building.errors.full_messages}"
+        end
+
+      redirect_to action: "index"
     end
 
     private

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class UnitsController < AdminController
     before_action :load_building
-    before_action :load_unit, only: [:edit, :update]
+    before_action :load_unit, only: [:edit, :update, :destroy]
 
     def index
       @units = @building.units
@@ -28,6 +28,17 @@ module Admin
         error_flash
         render action: "edit"
       end
+    end
+
+    def destroy
+      flash[:alert] =
+        if @unit.destroy
+          "Unit deleted."
+        else
+          "Delete failed: #{@unit.errors.full_messages}"
+        end
+
+      redirect_to action: "index"
     end
 
     private

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -1,10 +1,17 @@
 module Admin
   class UnitsController < AdminController
     before_action :load_building
-    before_action :load_unit, only: [:edit, :update, :destroy]
+    before_action :load_unit, only: [:edit, :update, :destroy, :show]
 
     def index
-      @units = @building.units
+      respond_to do |format|
+        format.html { @units = @building.units }
+        format.json do
+          render json: {
+            results: @building.units.as_json(only: [:id, :name])
+          }
+        end
+      end
     end
 
     def create

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class UnitsController < AdminController
-    before_action :load_building, only: [:index, :new, :create]
+    before_action :load_building
     before_action :load_unit, only: [:edit, :update]
 
     def index

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -1,0 +1,55 @@
+module Admin
+  class UnitsController < AdminController
+    before_action :load_building, only: [:index, :new, :create]
+    before_action :load_unit, only: [:edit, :update]
+
+    def index
+      @units = @building.units
+    end
+
+    def create
+      params[:unit][:building_id] ||= @building.id
+      @unit = Unit.new(unit_params)
+
+      if @unit.save
+        flash[:notice] = "Successfully created."
+        redirect_to admin_building_units_path(@building)
+      else
+        error_flash
+        render action: "new"
+      end
+    end
+
+    def update
+      if @unit.update_attributes(unit_params)
+        flash[:notice] = "Successfully updated."
+        redirect_to(action: "edit", id: @unit)
+      else
+        error_flash
+        render action: "edit"
+      end
+    end
+
+    private
+
+    def unit_params
+      params.require(:unit).permit(:building_id,
+                                   :name,
+                                   :floor,
+                                   :description)
+    end
+
+    def load_building
+      @building = Building.find(params[:building_id])
+    end
+
+
+    def load_unit
+      @unit = Unit.find(params[:id])
+    end
+
+    def error_flash
+      flash.now[:error] = "Save failed due to errors."
+    end
+  end
+end

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -23,7 +23,7 @@ module Admin
     def update
       if @unit.update_attributes(unit_params)
         flash[:notice] = "Successfully updated."
-        redirect_to(action: "edit", id: @unit)
+        redirect_to admin_building_units_path(@building)
       else
         error_flash
         render action: "edit"
@@ -42,7 +42,6 @@ module Admin
     def load_building
       @building = Building.find(params[:building_id])
     end
-
 
     def load_unit
       @unit = Unit.find(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,6 +60,10 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @unit_options = @user.unit ? @user.unit.options_for_select_in_building : []
+  end
+
   def edit_password
     @user = current_user
   end
@@ -153,7 +157,9 @@ class UsersController < ApplicationController
         :phone_number,
         :zip_code,
         :permissions,
-        :twine_name
+        :twine_name,
+        :building_id,
+        :unit_id
       ])
     end
 

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,5 +1,5 @@
 class Building < ActiveRecord::Base
-  has_many :units
+  has_many :units, dependent: :restrict
   has_many :tenants, through: :units, class_name: User.name
 
   validates_presence_of :street_address, :zip_code
@@ -16,5 +16,9 @@ class Building < ActiveRecord::Base
 
   def street_and_zip
     [street_address, zip_code].join(" | ")
+  end
+
+  def can_destroy?
+    units.empty?
   end
 end

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -11,6 +11,10 @@ class Building < ActiveRecord::Base
   before_save { |building| building.street_address = building.street_address.downcase }
 
   def address_and_name
-    [street_address, zip_code, property_name].join(" | ")
+    [street_address, zip_code, property_name].compact.join(" | ")
+  end
+
+  def street_and_zip
+    [street_address, zip_code].join(" | ")
   end
 end

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -11,7 +11,7 @@ class Building < ActiveRecord::Base
   before_save { |building| building.street_address = building.street_address.downcase }
 
   def address_and_name
-    [street_address, zip_code, property_name].compact.join(" | ")
+    [street_address.titlecase, zip_code, property_name].compact.join(" | ")
   end
 
   def street_and_zip

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,5 +1,5 @@
 class Building < ActiveRecord::Base
-  has_many :units, dependent: :restrict
+  has_many :units, dependent: :restrict_with_exception
   has_many :tenants, through: :units, class_name: User.name
 
   validates_presence_of :street_address, :zip_code
@@ -15,10 +15,18 @@ class Building < ActiveRecord::Base
   end
 
   def street_and_zip
-    [street_address, zip_code].join(" | ")
+    [street_address.titlecase, zip_code].join(" | ")
   end
 
   def can_destroy?
     units.empty?
+  end
+
+  def self.options_for_select
+    {}.tap do |options|
+      all.each do |building|
+        options[building.street_and_zip] = building.id
+      end
+    end
   end
 end

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -9,4 +9,8 @@ class Building < ActiveRecord::Base
   validates :street_address, uniqueness: { scope: :zip_code, case_sensitive: false }
 
   before_save { |building| building.street_address = building.street_address.downcase }
+
+  def address_and_name
+    [street_address, zip_code, property_name].join(" | ")
+  end
 end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -10,4 +10,12 @@ class Unit < ActiveRecord::Base
   def can_destroy?
     tenants.empty?
   end
+
+  def options_for_select_in_building
+    {}.tap do |options|
+      building.units.each do |unit|
+        options[unit.name.upcase] = unit.id
+      end
+    end
+  end
 end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,6 +1,6 @@
 class Unit < ActiveRecord::Base
   belongs_to :building
-  has_many :tenants, class_name: User.name, dependent: :restrict
+  has_many :tenants, class_name: User.name, dependent: :restrict_with_exception
 
   validates_presence_of :building, :name
   validates :name, uniqueness: { scope: :building, case_sensitive: false }

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,9 +1,13 @@
 class Unit < ActiveRecord::Base
   belongs_to :building
-  has_many :tenants, class_name: User.name
+  has_many :tenants, class_name: User.name, dependent: :restrict
 
   validates_presence_of :building, :name
   validates :name, uniqueness: { scope: :building, case_sensitive: false }
 
   before_save { |unit| unit.name = unit.name.downcase }
+
+  def can_destroy?
+    tenants.empty?
+  end
 end

--- a/app/views/admin/buildings/edit.html.erb
+++ b/app/views/admin/buildings/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "form",
            locals: {
-             title: "Edit #{[@building.property_name, @building.street_address, @building.zip_code].compact.join(" - ")}",
+             title: "Edit #{@building.address_and_name}",
              resource: @building,
              url: admin_building_path(@building),
              action_label: "UPDATE"

--- a/app/views/admin/buildings/index.html.erb
+++ b/app/views/admin/buildings/index.html.erb
@@ -1,14 +1,41 @@
-<div class="col-xs-6 container">
-  <h1 id="collaborator-h1" class="text-center">Buildings</h1>
-  <%= link_to "Create Building", new_admin_building_path %>
+<div class="advocate-layout clearfix">
+  <div class="container">
+    <div class="col-xs-12 container" id="permissions-show-div">
+      <div>
+        <h1 id="collaborator-h1" class="text-center">Buildings</h1>
+      </div>
 
-  <% @buildings.each do |building| %>
-    <hr class="underline-user text-center">
-    <li class="sidebar-li">
-      <!-- TODO: Add a link/button to path for building/:id/units/ -->
-      <a href="<%= edit_admin_building_path(building) %>" class="user-link">
-        <%= building.address_and_name %>
-      </a>
-    </li>
-  <% end %>
+      <%= link_to "Create Building", new_admin_building_path %>
+
+      <ul id="collaborator-ul">
+        <% @buildings.each do |building| %>
+          <li class="sidebar-li">
+            <div class="collaborator-link-div">
+              <%= link_to(building.street_and_zip,
+                          admin_building_units_path(building),
+                          method: :get,
+                          class: "user-link") %>
+              <p class="address_zip">
+                Property Name: <%= building.property_name %>
+              </p>
+            </div>
+
+            <%= link_to("",
+                        admin_building_path(building),
+                        method: :delete,
+                        class: "fa fa-times remove-user-link",
+                        id: "edit",
+                        data: { confirm: "Are you sure?" },
+                        data: { remote: true }) %>
+
+            <%= link_to("",
+                        edit_admin_building_path(building),
+                        class: "fa fa-wrench user-settings-link",
+                        id: "wrench") %>
+            <br>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
 </div>

--- a/app/views/admin/buildings/index.html.erb
+++ b/app/views/admin/buildings/index.html.erb
@@ -20,12 +20,14 @@
               </p>
             </div>
 
-            <%= link_to("",
-                        admin_building_path(building),
-                        method: :delete,
-                        class: "fa fa-times remove-user-link",
-                        id: "edit",
-                        data: { confirm: "Do you want to delete this building?" })%>
+            <% if building.can_destroy? %>
+              <%= link_to("",
+                          admin_building_path(building),
+                          method: :delete,
+                          class: "fa fa-times remove-user-link",
+                          id: "edit",
+                          data: { confirm: "Do you want to delete this building?" })%>
+            <% end %>
 
             <%= link_to("",
                         edit_admin_building_path(building),

--- a/app/views/admin/buildings/index.html.erb
+++ b/app/views/admin/buildings/index.html.erb
@@ -1,6 +1,6 @@
 <div class="col-xs-6 container">
   <h1 id="collaborator-h1" class="text-center">Buildings</h1>
-  <%= link_to "Add Building", new_admin_building_path %>
+  <%= link_to "Create Building", new_admin_building_path %>
 
   <% @buildings.each do |building| %>
     <hr class="underline-user text-center">

--- a/app/views/admin/buildings/index.html.erb
+++ b/app/views/admin/buildings/index.html.erb
@@ -9,7 +9,7 @@
 
       <ul id="collaborator-ul">
         <% @buildings.each do |building| %>
-          <li class="sidebar-li">
+          <li id="building-<%= building.id %>" class="sidebar-li">
             <div class="collaborator-link-div">
               <%= link_to(building.street_and_zip,
                           admin_building_units_path(building),
@@ -25,8 +25,7 @@
                         method: :delete,
                         class: "fa fa-times remove-user-link",
                         id: "edit",
-                        data: { confirm: "Are you sure?" },
-                        data: { remote: true }) %>
+                        data: { confirm: "Do you want to delete this building?" })%>
 
             <%= link_to("",
                         edit_admin_building_path(building),

--- a/app/views/admin/buildings/index.html.erb
+++ b/app/views/admin/buildings/index.html.erb
@@ -1,11 +1,13 @@
 <div class="col-xs-6 container">
   <h1 id="collaborator-h1" class="text-center">Buildings</h1>
   <%= link_to "Add Building", new_admin_building_path %>
-  <% @buildings.each do |b| %>
+
+  <% @buildings.each do |building| %>
     <hr class="underline-user text-center">
     <li class="sidebar-li">
-      <a href="<%= edit_admin_building_path(b.id) %>" class="user-link">
-        <%= [b.street_address, b.zip_code, b.property_name].join(" | ") %>
+      <!-- TODO: Add a link/button to path for building/:id/units/ -->
+      <a href="<%= edit_admin_building_path(building) %>" class="user-link">
+        <%= building.address_and_name %>
       </a>
     </li>
   <% end %>

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -1,0 +1,21 @@
+<div id="form-id">
+  <div class="container form-header">
+    <div class="form-title">
+      <h1><%= title %></h1>
+    </div>
+  </div>
+
+  <%= semantic_form_for(resource, url: url) do |f| %>
+    <div class="container form-fields col-lg-5 col-md-6 col-sm-6 col-xs-12">
+      <%= f.semantic_errors %>
+      <%= f.inputs do %>
+        <%= f.input :name, input_html: { class: "short-field" } %>
+        <%= f.input :floor, input_html: { class: "short-field" } %>
+        <%= f.input :description %>
+      <% end %>
+      <%= f.actions do %>
+        <% f.action :submit, label: action_label, button_html: { class: "btn-save" } %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -9,7 +9,7 @@
     <div class="container form-fields col-lg-5 col-md-6 col-sm-6 col-xs-12">
       <%= f.semantic_errors %>
       <%= f.inputs do %>
-        <%= f.input :name, input_html: { class: "short-field" } %>
+        <%= f.input :name, input_html: { class: "short-field uppercase-field" } %>
         <%= f.input :floor, input_html: { class: "short-field" } %>
         <%= f.input :description %>
       <% end %>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -2,6 +2,6 @@
            locals: {
              title: "Edit #{@unit.name} in #{@building.address_and_name}",
              resource: @unit,
-             url: edit_admin_building_unit_path(@building, @unit),
+             url: admin_building_unit_path(@building, @unit),
              action_label: "UPDATE"
            } %>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: "form",
+           locals: {
+             title: "Edit #{@unit.name} in #{@building.address_and_name}",
+             resource: @unit,
+             url: edit_admin_building_unit_path(@building, @unit),
+             action_label: "UPDATE"
+           } %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -17,11 +17,25 @@
             <li class="sidebar-li">
               <div class="collaborator-link-div">
                 <%= link_to(unit.name.upcase,
-                            edit_admin_building_unit_path(@building, unit),
+                            admin_building_unit_path(@building, unit),
                             method: :get,
                             class: "user-link") %>
-                <p><%= unit.description %></p>
+                <p class="address_zip">Description: <%= unit.description %></p>
               </div>
+
+              <%= link_to("",
+                          admin_building_unit_path(@building, unit),
+                          method: :delete,
+                          class: "fa fa-times remove-user-link",
+                          id: "edit",
+                          data: { confirm: "Are you sure?" },
+                          data: { remote: true }) %>
+
+              <%= link_to("",
+                          edit_admin_building_unit_path(@building, unit),
+                          class: "fa fa-wrench user-settings-link",
+                          id: "wrench") %>
+              <br>
             </li>
           </div>
         <% end %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -1,17 +1,31 @@
-<div id="form-id">
-  <div class="container form-header">
-    <div class="form-title">
-      <h1>Units in <%= @building.address_and_name %></h1>
+<div class="advocate-layout clearfix">
+  <div class="container">
+    <div class="col-xs-12 container" id="permissions-show-div">
+      <div>
+        <h1 id="collaborator-h1" class="text-center">
+          Units in <%= @building.address_and_name %>
+        </h1>
+      </div>
 
-      <% @units.each do |u| %>
-        <hr class="underline-user text-center">
-        <li class="sidebar-li">
-          <!-- Path to nested building/:id/units/ resource -->
-          <a href="<%= edit_admin_building_unit_path(@building.id, u.id) %>" class="user-link">
-            <%= u.name %>
-          </a>
-        </li>
-      <% end %>
+      <a class="btn" href="<%= new_admin_building_unit_path(@building) %>">
+        Create New Unit
+      </a>
+
+      <ul id="collaborator-ul">
+        <% @units.each do |unit| %>
+          <div>
+            <li class="sidebar-li">
+              <div class="collaborator-link-div">
+                <%= link_to(unit.name.upcase,
+                            edit_admin_building_unit_path(@building, unit),
+                            method: :get,
+                            class: "user-link") %>
+                <p><%= unit.description %></p>
+              </div>
+            </li>
+          </div>
+        <% end %>
+      </ul>
     </div>
   </div>
 </div>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -13,7 +13,7 @@
 
       <ul id="collaborator-ul">
         <% @units.each do |unit| %>
-          <li class="sidebar-li">
+          <li id="unit-<%= unit.id %>" class="sidebar-li">
             <div class="collaborator-link-div">
               <%= link_to(unit.name.upcase,
                           admin_building_unit_path(@building, unit),
@@ -27,8 +27,7 @@
                         method: :delete,
                         class: "fa fa-times remove-user-link",
                         id: "edit",
-                        data: { confirm: "Are you sure?" },
-                        data: { remote: true }) %>
+                        data: { confirm: "Do you want to delete this unit?" }) %>
 
             <%= link_to("",
                         edit_admin_building_unit_path(@building, unit),

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -13,31 +13,29 @@
 
       <ul id="collaborator-ul">
         <% @units.each do |unit| %>
-          <div>
-            <li class="sidebar-li">
-              <div class="collaborator-link-div">
-                <%= link_to(unit.name.upcase,
-                            admin_building_unit_path(@building, unit),
-                            method: :get,
-                            class: "user-link") %>
-                <p class="address_zip">Description: <%= unit.description %></p>
-              </div>
-
-              <%= link_to("",
+          <li class="sidebar-li">
+            <div class="collaborator-link-div">
+              <%= link_to(unit.name.upcase,
                           admin_building_unit_path(@building, unit),
-                          method: :delete,
-                          class: "fa fa-times remove-user-link",
-                          id: "edit",
-                          data: { confirm: "Are you sure?" },
-                          data: { remote: true }) %>
+                          method: :get,
+                          class: "user-link") %>
+              <p class="address_zip">Description: <%= unit.description %></p>
+            </div>
 
-              <%= link_to("",
-                          edit_admin_building_unit_path(@building, unit),
-                          class: "fa fa-wrench user-settings-link",
-                          id: "wrench") %>
-              <br>
-            </li>
-          </div>
+            <%= link_to("",
+                        admin_building_unit_path(@building, unit),
+                        method: :delete,
+                        class: "fa fa-times remove-user-link",
+                        id: "edit",
+                        data: { confirm: "Are you sure?" },
+                        data: { remote: true }) %>
+
+            <%= link_to("",
+                        edit_admin_building_unit_path(@building, unit),
+                        class: "fa fa-wrench user-settings-link",
+                        id: "wrench") %>
+            <br>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -1,0 +1,17 @@
+<div id="form-id">
+  <div class="container form-header">
+    <div class="form-title">
+      <h1>Units in <%= @building.address_and_name %></h1>
+
+      <% @units.each do |u| %>
+        <hr class="underline-user text-center">
+        <li class="sidebar-li">
+          <!-- Path to nested building/:id/units/ resource -->
+          <a href="<%= edit_admin_building_unit_path(@building.id, u.id) %>" class="user-link">
+            <%= u.name %>
+          </a>
+        </li>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/units/new.html.erb
+++ b/app/views/admin/units/new.html.erb
@@ -2,6 +2,6 @@
            locals: {
              title: "Create Unit in #{@building.address_and_name}",
              resource: @unit || Unit.new,
-             url: new_admin_building_unit_path(@building),
+             url: admin_building_units_path(@building),
              action_label: "CREATE"
            } %>

--- a/app/views/admin/units/new.html.erb
+++ b/app/views/admin/units/new.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: "form",
+           locals: {
+             title: "Create Unit in #{@building.address_and_name}",
+             resource: @unit || Unit.new,
+             url: new_admin_building_unit_path(@building),
+             action_label: "CREATE"
+           } %>

--- a/app/views/admin/units/show.html.erb
+++ b/app/views/admin/units/show.html.erb
@@ -1,0 +1,5 @@
+<div>
+<!-- Maybe this should not be under /admin namespace so all Admin can see it -->
+<!-- Name, Floor, Description -->
+<!-- List of tenants -->
+</div>

--- a/app/views/admin/units/show.html.erb
+++ b/app/views/admin/units/show.html.erb
@@ -1,5 +1,24 @@
-<div>
-<!-- Maybe this should not be under /admin namespace so all Admin can see it -->
-<!-- Name, Floor, Description -->
-<!-- List of tenants -->
+<div class="advocate-layout clearfix">
+  <div class="container">
+    <div class="col-xs-12 container" id="permissions-show-div">
+      <div>
+        <h1 id="collaborator-h1" class="text-center">Unit Information</h1>
+      </div>
+
+      <div><%= @building.address_and_name %></div>
+      <div><%= @unit.name %></div>
+      <div><%= @unit.floor %></div>
+      <div>Tenants
+        <ul>
+        <% @unit.tenants.each do |tenant| %>
+          <li>
+            <%= tenant.first_name %>
+            <%= tenant.last_name %>
+            <!-- TODO: Include the rest of the Tenant data to display -->
+          </li>
+        <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -11,7 +11,9 @@
       <%= f.inputs do %>
         <%= f.input :first_name %>
         <%= f.input :last_name %>
-        <%= f.input :apartment, input_html: { class: "short-field" } %>
+        <%= f.input :apartment,
+                    label: "Apartment (Legacy)",
+                    input_html: { class: "short-field" } %>
         <%= f.input :address %>
         <%= f.input :zip_code, input_html: { class: "short-field" } %>
         <%= f.input :phone_number, input_html: { class: "short-field" } %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,44 +1,40 @@
 <div id="form-id">
   <div class="container settings-header">
     <div class="settings-title">
-      <h1>Edit <%= "#{@user.first_name} #{@user.last_name}" %>'s Settings </h1>
+      <h1>Edit <%= "#{@user.first_name} #{@user.last_name}" %>'s Settings</h1>
     </div>
-  </div><!--end of settigs title -->
+  </div>
 
-  <%= form_for(@user) do |f| %>
-    <div class="container settings-form-fields col-lg-5 col-md-6 col-sm-6 col-xs-12">
-      <dl class="settings-input"><%= f.label :first_name %>
-      <%= f.text_field :first_name, :autofocus => true, class: "form-control" %></dl>
-
-      <dl class="settings-input"><%= f.label :last_name %>
-      <%= f.text_field :last_name, class: "form-control" %></dl>
-
-      <dl class="settings-input"><%= f.label :apartment %>
-      <%= f.text_field :apartment, class: "form-control short-field" %></dl>
-
-      <dl class="settings-input"><%= f.label :address %>
-      <%= f.text_field :address, class: "form-control" %></dl>
-
-      <dl class="settings-input"><%= f.label :zip_code %>
-      <%= f.text_field :zip_code, class: "form-control short-field" %></dl>
-
-      <dl class="settings-input"><%= f.label :phone_number %>
-      <%= f.text_field :phone_number, class: "form-control short-field" %></dl>
-
-      <dl class="settings-input"><%= f.label :twine_name %>
-      <%= f.text_field :twine_name, class: "form-control" %></dl>
-      
-      <% if @user.permissions > 0 && !@user.is_demo_user? %>
-        <dl class="settings-input settings-permissions"><%= f.label :permissions %>
-          <%= f.select :permissions,
-                       current_user.list_permission_level_and_lower,
-                       class: "form-control" %>
-        </dl>
-
-      <dl class="settings-input">
-      <%= f.submit "SAVE", class: "btn-save" %></dl>
-
-      </div><!--end of settings form-->
-    <% end %>
+  <%= semantic_form_for(@user) do |f| %>
+    <div class="container user-settings settings-form-fields col-lg-5 col-md-6 col-sm-6 col-xs-12">
+      <%= f.semantic_errors %>
+      <%= f.inputs do %>
+        <%= f.input :first_name %>
+        <%= f.input :last_name %>
+        <%= f.input :apartment, input_html: { class: "short-field" } %>
+        <%= f.input :address %>
+        <%= f.input :zip_code, input_html: { class: "short-field" } %>
+        <%= f.input :phone_number, input_html: { class: "short-field" } %>
+        <%= f.input :twine_name %>
+        <%= f.input :building_id,
+                    as: :select,
+                    collection: Building.options_for_select,
+                    include_blank: true %>
+        <%= f.input :unit_id,
+                    as: :select,
+                    collection: @unit_options,
+                    include_blank: true %>
+        <% if @user.permissions > 0 && !@user.is_demo_user? %>
+          <%= f.input :permissions,
+                      as: :select,
+                      collection: current_user.list_permission_level_and_lower,
+                      include_blank: true,
+                      input_html: { class: "short-field" } %>
+        <% end %>
+      <% end %>
+      <%= f.actions do %>
+        <% f.action :submit, label: "SAVE", button_html: { class: "btn-save" } %>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,9 @@ Twinenyc::Application.routes.draw do
   get "vote-for-us" => "welcome#nycbigapps"
 
   namespace :admin do
-    resources :buildings
+    resources :buildings do
+      resources :units
+    end
   end
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/spec/features/managing_buildings_spec.rb
+++ b/spec/features/managing_buildings_spec.rb
@@ -32,7 +32,7 @@ feature "Building management" do
   scenario "Creating a new building" do
     visit "/"
     click_link "Buildings"
-    click_link "Add Building"
+    click_link "Create Building"
 
     fill_in "Property name", with: "New apartment"
     fill_in "Street address", with: "123 New St"

--- a/spec/features/managing_buildings_spec.rb
+++ b/spec/features/managing_buildings_spec.rb
@@ -90,4 +90,17 @@ feature "Building management" do
     expect(page).to have_content("can't be blank")
     expect(building.reload.street_address).to_not be_blank
   end
+
+  scenario "Deleting a building" do
+    building
+    visit admin_buildings_path
+
+    within(:css, "li#building-#{building.id}") do
+      find("a.remove-user-link").click
+    end
+
+    expect(current_path).to eq(admin_buildings_path)
+    expect(page).to have_content("Building deleted.")
+    expect { building.reload }.to raise_error { ActiveRecord::RecordNotFound }
+  end
 end

--- a/spec/features/managing_buildings_spec.rb
+++ b/spec/features/managing_buildings_spec.rb
@@ -18,7 +18,7 @@ feature "Building management" do
 
   before { login_as_team_member }
 
-  scenario "Viewing index" do
+  scenario "Viewing index of all buildings" do
     building
     building_2 = create(:building, street_address: "100 Another Street")
 
@@ -27,6 +27,13 @@ feature "Building management" do
 
     expect(page).to have_content(building.street_address)
     expect(page).to have_content(building_2.street_address)
+  end
+
+  scenario "Viewing all units associated with a building" do
+    building
+    visit admin_buildings_path(building)
+    click_link building.address_and_name
+    expect(current_path).to eq(admin_building_units_path(building))
   end
 
   scenario "Creating a new building" do

--- a/spec/features/managing_buildings_spec.rb
+++ b/spec/features/managing_buildings_spec.rb
@@ -25,14 +25,14 @@ feature "Building management" do
     visit "/"
     click_link "Buildings"
 
-    expect(page).to have_content(building.street_address)
-    expect(page).to have_content(building_2.street_address)
+    expect(page).to have_content(building.street_and_zip)
+    expect(page).to have_content(building_2.street_and_zip)
   end
 
   scenario "Viewing all units associated with a building" do
     building
     visit admin_buildings_path(building)
-    click_link building.address_and_name
+    click_link building.street_and_zip
     expect(current_path).to eq(admin_building_units_path(building))
   end
 

--- a/spec/features/managing_units_spec.rb
+++ b/spec/features/managing_units_spec.rb
@@ -89,4 +89,16 @@ feature "Unit management" do
     expect(page).to have_content("Save failed due to errors.")
     expect(page).to have_content("can't be blank")
   end
+
+  scenario "Deleting a unit" do
+    visit admin_building_units_path(existing_unit.building)
+
+    within(:css, "li#unit-#{existing_unit.id}") do
+      find("a.remove-user-link").click
+    end
+
+    expect(current_path).to eq(admin_building_units_path(building))
+    expect(page).to have_content("Unit deleted.")
+    expect { existing_unit.reload }.to raise_error { ActiveRecord::RecordNotFound }
+  end
 end

--- a/spec/features/managing_units_spec.rb
+++ b/spec/features/managing_units_spec.rb
@@ -13,8 +13,8 @@ feature "Unit management is restricted to admin users" do
     visit "/admin/buildings/#{building.id}/units/new"
     expect(current_path).to eq(root_path)
 
-    # visit "/admin/buildings/#{building.id}/units/#{unit.id}/edit"
-    # expect(current_path).to eq(root_path)
+    visit "/admin/buildings/#{building.id}/units/#{unit.id}/edit"
+    expect(current_path).to eq(root_path)
   end
 end
 
@@ -45,5 +45,16 @@ feature "Unit management" do
     expect(current_path).to eq(admin_building_units_path(building))
     expect(page).to have_content("Successfully created.")
     expect(page).to have_content(building.units.last.name.upcase)
+  end
+
+  scenario "Creating a new unit displays validation errors" do
+    visit building_units_path
+    click_link "Create New Unit"
+
+    fill_in "Floor", with: 1
+    click_button "CREATE"
+
+    expect(page).to have_content("Save failed due to errors.")
+    expect(page).to have_content("can't be blank")
   end
 end

--- a/spec/features/managing_units_spec.rb
+++ b/spec/features/managing_units_spec.rb
@@ -71,13 +71,11 @@ feature "Unit management" do
 
     click_button "UPDATE"
 
-    expect(current_path).to eq(edit_admin_building_unit_path(building, existing_unit))
+    expect(current_path).to eq(admin_building_units_path(building))
     expect(page).to have_content("Successfully updated.")
-    # expect(page).to have_content("5B") currently fails even though the value
-    # is rendered in uppercase with the CSS class so we use lowercase comparison
-    expect(find_field("Name").value).to eq("5b")
-    expect(find_field("Floor").value).to eq("4")
-    expect(find_field("Description").value).to eq("This is different")
+    expect(page).to have_content("5B")
+    expect(page).to have_content("4")
+    expect(page).to have_content("This is different")
   end
 
   scenario "Updating a unit displays validation errors" do
@@ -86,9 +84,9 @@ feature "Unit management" do
     fill_in "Name", with: ""
 
     click_button "UPDATE"
+
+    expect(current_path).to eq(admin_building_unit_path(building, existing_unit))
     expect(page).to have_content("Save failed due to errors.")
     expect(page).to have_content("can't be blank")
-    expect(existing_unit.reload.name).to_not be_blank
   end
-
 end

--- a/spec/features/managing_units_spec.rb
+++ b/spec/features/managing_units_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+feature "Unit management is restricted to admin users" do
+  scenario "Denies access to a non-admin user" do
+    building = create(:building)
+    unit = building.units.create(name: "1A", floor: 1)
+
+    login_as_tenant
+
+    visit "/admin/buildings/#{building.id}/units"
+    expect(current_path).to eq(root_path)
+
+    visit "/admin/buildings/#{building.id}/units/new"
+    expect(current_path).to eq(root_path)
+
+    # visit "/admin/buildings/#{building.id}/units/#{unit.id}/edit"
+    # expect(current_path).to eq(root_path)
+  end
+end
+
+feature "Unit management" do
+  let(:building) { create(:building) }
+  let(:building_units_path) { "/admin/buildings/#{building.id}/units/" }
+
+  before { login_as_team_member }
+
+  scenario "Viewing index" do
+    unit = building.units.create(name: "1A", floor: 1)
+    visit building_units_path
+
+    expect(page).to have_content(unit.name)
+    expect(page).to have_content(unit.floor)
+  end
+
+  scenario "Creating a new unit" do
+    visit building_units_path
+    click_button "CREATE NEW UNIT"
+
+    fill_in "Name", with: "2A"
+    fill_in "Floor", with: 2
+    fill_in "Description", with: "A cozy and charming (overpriced) loft."
+
+    click_button "CREATE"
+
+    expect(current_path).to eq(admin_building_unit_path(building))
+    expect(page).to have_content("Successfully created.")
+    expect(page).to have_content(building.units.last.name)
+  end
+end

--- a/spec/features/managing_units_spec.rb
+++ b/spec/features/managing_units_spec.rb
@@ -28,13 +28,13 @@ feature "Unit management" do
     unit = building.units.create(name: "1A", floor: 1)
     visit building_units_path
 
-    expect(page).to have_content(unit.name)
+    expect(page).to have_content(unit.name.upcase)
     expect(page).to have_content(unit.floor)
   end
 
   scenario "Creating a new unit" do
     visit building_units_path
-    click_button "CREATE NEW UNIT"
+    click_link "Create New Unit"
 
     fill_in "Name", with: "2A"
     fill_in "Floor", with: 2
@@ -42,8 +42,8 @@ feature "Unit management" do
 
     click_button "CREATE"
 
-    expect(current_path).to eq(admin_building_unit_path(building))
+    expect(current_path).to eq(admin_building_units_path(building))
     expect(page).to have_content("Successfully created.")
-    expect(page).to have_content(building.units.last.name)
+    expect(page).to have_content(building.units.last.name.upcase)
   end
 end

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -83,4 +83,19 @@ describe Building do
       expect(building_2).to be_valid
     end
   end
+
+  describe "destroy restrictions" do
+    before { create(:unit, building: building) }
+
+    it "raises an error if there are associated units" do
+      expect { building.destroy }
+        .to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+
+    it "has a method to check if it can be destroyed" do
+      expect(building.can_destroy?).to eq(false)
+      building.units.destroy_all
+      expect(building.can_destroy?).to eq(true)
+    end
+  end
 end

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -9,7 +9,7 @@ describe Building do
       another_unit = create(:unit, building: building)
       building.units << new_unit
       building.units << another_unit
-      expect(building.units).to eq([new_unit, another_unit])
+      expect(building.units).to match_array([new_unit, another_unit])
     end
 
     it "has tenants through the Unit model" do
@@ -20,7 +20,7 @@ describe Building do
       unit_1.tenants << user_1
       unit_2.tenants << user_2
 
-      expect(building.tenants).to eq([user_1, user_2])
+      expect(building.tenants).to match_array([user_1, user_2])
     end
   end
 

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -32,4 +32,19 @@ describe Unit do
       expect(unit.tenants.count).to eq(2)
     end
   end
+
+  describe "destroy restrictions" do
+    before { create(:user, unit: unit) }
+
+    it "raises an error if there are associated tenants" do
+      expect { unit.destroy }
+        .to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+
+    it "has a method to check if it can be destroyed" do
+      expect(unit.can_destroy?).to eq(false)
+      unit.tenants.destroy_all
+      expect(unit.can_destroy?).to eq(true)
+    end
+  end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -11,4 +11,5 @@ VCR.configure do |c|
   c.debug_logger = File.open(Rails.root.join('log', 'vcr.log'), 'a')
   c.filter_sensitive_data('---WUNDERGROUND_KEY---') { ENV['WUNDERGROUND_KEY'] }
   c.configure_rspec_metadata!
+  c.ignore_localhost = true
 end


### PR DESCRIPTION
@williamcodes This PR completes the ability to assign a Building and a Unit to a User form (there still needs to be view/layout improvements), but the issue I'm having right now is getting JS acceptance tests to run properly.  I was able to get tests to run when I switch database type from Sqlite to Postgres, but Sqlite gets an empty database (due to how selenium/poltergeist launches a separate process from what I've been reading, but I haven't been able to crack the configuration issues yet).

I'm still out of state until next week, but would like to pair with you next week if you have the time to cover all the changes with this branch and see if you have more insight into how to get JS integration tests working.

Currently, the JS being used is that when you select the building, the form makes an ajax request to load the form options for all the unit names associated with that building.
