### PR TITLE
Add BBL data to buildings

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,4 @@
 GEOCODE_API_KEY=dummy-key
 WUNDERGROUND_KEY=dummy-key
+GEOCLIENT_APP_ID=dummy-app-id
+GEOCLIENT_APP_KEY=dummy-app-key

--- a/README.md
+++ b/README.md
@@ -74,12 +74,22 @@ The weather update task requires a Wunderground API token, which can be generate
 rake weather:update
 ```
 
+The BBL backfill task requires a Geoclient App id and token, which can be generated [here](https://developer.cityofnewyork.us/api/geoclient-api).
+
+```
+rake data:backfill_bbl
+```
+
 This project uses the [Dotenv](https://github.com/bkeepers/dotenv) gem to store environment variables so add a `.env.development.local` file to the root of this project with the following:
 
 ```
 GEOCODE_API_KEY=<token>
 WUNDERGROUND_KEY=<token>
+GEOCLIENT_APP_ID=<token>
+GEOCLIENT_APP_KEY=<token>
 ```
+
+
 
 ## License
 

--- a/app/tasks/add_bbl_data_to_buildings.rb
+++ b/app/tasks/add_bbl_data_to_buildings.rb
@@ -1,0 +1,49 @@
+require "httparty"
+
+class AddBBLDataToBuildings
+  def self.exec(timeout)
+    buildings_updated = 0
+
+    Building.where("state = 'new york' OR state = 'New York'").each do |b|
+      next if b.bbl
+
+      response = HTTParty.get(
+          "https://api.cityofnewyork.us/geoclient/v1/address.json",
+          { query: query_params(b).merge(access_params) }
+      )
+
+      sleep timeout
+
+      begin
+        payload = JSON.parse(response.body)["address"]
+        b.bbl = payload["bbl"].gsub(/\D/, '')
+      rescue Exception => e
+        puts "Error occurred with #{b.street_address}: #{response.code} #{response.message}"
+        puts e.message
+        next
+      end
+
+      if b.save
+        buildings_updated += 1
+        puts "Updated #{b.street_address}"
+      end
+    end
+
+    puts "updated #{buildings_updated} of #{Building.count} buildings"
+  end
+
+  private
+
+  def self.query_params(building)
+    address = building.street_address.split(',')[0].split
+    {
+      houseNumber: address.shift,
+      street: address.join(" "),
+      zip: building.zip_code
+    }
+  end
+
+  def self.access_params
+    { app_id: ENV["GEOCLIENT_APP_ID"], app_key: ENV["GEOCLIENT_APP_KEY"] }
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,8 +11,8 @@ unless User.find_by(email: 'mbeirut@heatseeknyc.com')
   User.create(
     :first_name => 'Jane',
     :last_name => 'Doe',
-    :address => '100 Fake St',
-    :zip_code => '11216',
+    :address => '625 6th Ave',
+    :zip_code => '10011',
     :email => 'jane@heatseeknyc.com',
     :password => '33west26',
     :apartment => '4C',
@@ -22,8 +22,8 @@ unless User.find_by(email: 'mbeirut@heatseeknyc.com')
   User.create(
     :first_name => 'John',
     :last_name => 'Doe',
-    :address => '100 Fake St',
-    :zip_code => '11216',
+    :address => '625 6th Ave',
+    :zip_code => '10011',
     :apartment => '4D',
     :email => 'john@heatseeknyc.com',
     :password => '33west26',
@@ -33,8 +33,8 @@ unless User.find_by(email: 'mbeirut@heatseeknyc.com')
   User.create(
       :first_name => 'Jamie',
       :last_name => 'Dough',
-      :address => '800 S Notreal Ave',
-      :zip_code => '11238',
+      :address => '636 6th Ave',
+      :zip_code => '10011',
       :email => 'jamie@heatseeknyc.com',
       :apartment => '6E',
       :password => '33west26'
@@ -43,8 +43,8 @@ unless User.find_by(email: 'mbeirut@heatseeknyc.com')
   User.create(
       :first_name => 'Jake',
       :last_name => 'Deaux',
-      :address => '200 Doesntexist Ln',
-      :zip_code => '10451',
+      :address => '636 6th Ave',
+      :zip_code => '10011',
       :email => 'jake@heatseeknyc.com',
       :password => '33west26'
   )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -152,11 +152,13 @@ users.each do |user|
     current_outdoor_temp += 2 if current_outdoor_temp < 25
 
     if user == demo
-      user.readings << Reading.new(created_at: current_time, temp: 68, outdoor_temp: current_outdoor_temp, user: user, twine: user.twine)
+      Reading.create(created_at: current_time, temp: 68, outdoor_temp: current_outdoor_temp, user: user)
     elsif user == jane && 100 < count && count < 124
       next
     else
-      user.readings << Reading.new(created_at: current_time, temp: current_temp, outdoor_temp: current_outdoor_temp, user: user, twine: user.twine)
+      Reading.create(created_at: current_time, temp: current_temp, outdoor_temp: current_outdoor_temp, user: user)
     end
   end
 end
+
+Reading.create(temp: 115, outdoor_temp: 37, user: jake, twine: jake.twine)

--- a/lib/tasks/data_scrubber.rake
+++ b/lib/tasks/data_scrubber.rake
@@ -6,6 +6,11 @@ namespace :data do
       3) associating each user with a building
   HEREDOC
   task scrub_data: :environment do
-    ScrubDataForBuildingsAndUsers.exec
+    ScrubDataForBuildingsAndUsers.exec(1)
+  end
+
+  desc "This task adds BBL numbers to buildings by querying the Geoclient API"
+  task backfill_bbl: :environment do
+    AddBBLDataToBuildings.exec(1)
   end
 end

--- a/spec/fixtures/fake_geocode_api_response.json
+++ b/spec/fixtures/fake_geocode_api_response.json
@@ -1,0 +1,64 @@
+{
+  "results" : [
+    {
+      "address_components" : [
+        {
+          "long_name" : "1600",
+          "short_name" : "1600",
+          "types" : [ "street_number" ]
+        },
+        {
+          "long_name" : "Amphitheatre Pkwy",
+          "short_name" : "Amphitheatre Pkwy",
+          "types" : [ "route" ]
+        },
+        {
+          "long_name" : "Mountain View",
+          "short_name" : "Mountain View",
+          "types" : [ "locality", "political" ]
+        },
+        {
+          "long_name" : "Santa Clara County",
+          "short_name" : "Santa Clara County",
+          "types" : [ "administrative_area_level_2", "political" ]
+        },
+        {
+          "long_name" : "New York",
+          "short_name" : "NY",
+          "types" : [ "administrative_area_level_1", "political" ]
+        },
+        {
+          "long_name" : "United States",
+          "short_name" : "US",
+          "types" : [ "country", "political" ]
+        },
+        {
+          "long_name" : "94043",
+          "short_name" : "94043",
+          "types" : [ "postal_code" ]
+        }
+      ],
+      "formatted_address" : "1600 Amphitheatre Parkway, Mountain View, CA 94043, USA",
+      "geometry" : {
+        "location" : {
+          "lat" : 37.4224764,
+          "lng" : -122.0842499
+        },
+        "location_type" : "ROOFTOP",
+        "viewport" : {
+          "northeast" : {
+            "lat" : 37.4238253802915,
+            "lng" : -122.0829009197085
+          },
+          "southwest" : {
+            "lat" : 37.4211274197085,
+            "lng" : -122.0855988802915
+          }
+        }
+      },
+      "place_id" : "ChIJ2eUgeAK6j4ARbn5u_wAGqWA",
+      "types" : [ "street_address" ]
+    }
+  ],
+  "status" : "OK"
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "rubygems"
 require "spork"
 require "simplecov"
 require "timecop"
+require "webmock/rspec"
 
 SimpleCov.start
 Timecop.travel(DateTime.parse("2015-03-01 00:00:00 -0500"))
@@ -48,8 +49,19 @@ Spork.prefork do
 
     config.before(:each) do
       Rails.cache.clear
+      WebMock.stub_request(:get, /maps\.googleapis\.com/)
+          .to_return(body: geocode_response)
     end
   end
+end
+
+
+def geocode_response
+  File.read(File.expand_path('spec/fixtures/fake_geocode_api_response.json'))
+end
+
+def geoclient_response
+  {address: {bbl: Faker::Number.number(10)}}
 end
 
 Spork.each_run do

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -12,5 +12,8 @@ VCR.configure do |c|
   c.filter_sensitive_data('---WUNDERGROUND_KEY---') { ENV['WUNDERGROUND_KEY'] }
   c.filter_sensitive_data('---GEOCODE_API_KEY---') { ENV['GEOCODE_API_KEY'] }
   c.default_cassette_options = { match_requests_on: [:method, :host, :path, :query] }
+  c.ignore_request do |r|
+    r.uri.match(/api\.cityofnewyork\.us/) || r.uri.match(/maps\.googleapis\.com/)
+  end
   c.configure_rspec_metadata!
 end

--- a/spec/tasks/add_bbl_data_to_buildings_spec.rb
+++ b/spec/tasks/add_bbl_data_to_buildings_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe AddBBLDataToBuildings do
+  TIMEOUT           = 0
+  GEOCLIENT_URI     = "https://api.cityofnewyork.us/geoclient/v1/address.json"
+  GEOCLIENT_MATCHER = /api\.cityofnewyork\.us/
+
+  let!(:bbl1) { geoclient_response }
+  let!(:bbl2) { geoclient_response }
+  let!(:building1) { FactoryGirl.build(:building, {street_address: "212-13 N 52nd St", zip_code: 10001}) }
+  let!(:building2) { FactoryGirl.build(:building, {street_address: "12 St John's Pl", zip_code: 10001}) }
+
+  before :each do
+
+    building1.save
+    building2.save
+  end
+
+  context "when everything is fine" do
+    let!(:access_params) { {app_id: ENV["GEOCLIENT_APP_ID"], app_key: ENV["GEOCLIENT_APP_KEY"]} }
+    let!(:building_with_bbl) { FactoryGirl.build(:building, {street_address: "360 Throop Ave",
+                                                             zip_code:       11221,
+                                                             bbl:            "1234567890"}) }
+
+    before :each do
+
+      WebMock.stub_request(:get, GEOCLIENT_MATCHER)
+          .to_return(body: bbl1.to_json).then
+          .to_return(body: bbl2.to_json)
+    end
+
+    it "asks the geoclient API for BBL" do
+      AddBBLDataToBuildings.exec(TIMEOUT)
+      expect(WebMock).to have_requested(:get, GEOCLIENT_URI)
+                             .with(query: {
+                                              houseNumber: "212-13",
+                                              street:      "N 52nd St",
+                                              zip:         building1.zip_code
+                                          }.merge(access_params))
+      expect(WebMock).to have_requested(:get, GEOCLIENT_URI)
+                             .with(query: {
+                                              houseNumber: 12,
+                                              street:      "St John's Pl",
+                                              zip:         building2.zip_code
+                                          }.merge(access_params))
+
+    end
+
+    it "skips building if there is already a bbl" do
+      building_with_bbl.save
+      AddBBLDataToBuildings.exec(TIMEOUT)
+
+      expect(WebMock).not_to have_requested(:get, GEOCLIENT_URI)
+                                 .with(query: {
+                                                  zip:         building_with_bbl.zip_code,
+                                                  houseNumber: "360",
+                                                  street:      "Throop Ave"
+                                              }.merge(access_params))
+    end
+
+    it "saves BBL data returned by geoclient API" do
+      AddBBLDataToBuildings.exec(TIMEOUT)
+      expect(building1.reload.bbl).to eq bbl1[:address][:bbl]
+      expect(building2.reload.bbl).to eq bbl2[:address][:bbl]
+    end
+  end
+
+  context "when response includes non-digit characters" do
+    before :each do
+      bbl1[:address][:bbl] = "123} 4567890"
+      WebMock.stub_request(:get, GEOCLIENT_MATCHER)
+          .to_return(body: bbl1.to_json)
+    end
+
+    it "scrubs non-digit characters before saving" do
+      AddBBLDataToBuildings.exec(TIMEOUT)
+
+      expect(building1.reload.bbl).to eq "1234567890"
+    end
+  end
+
+  context "when response is malformed" do
+    it "moves on to the next building" do
+      WebMock.stub_request(:get, GEOCLIENT_MATCHER)
+          .to_return(body: "this is not valid json").then
+          .to_return(body: bbl2.to_json)
+
+      expect { AddBBLDataToBuildings.exec(TIMEOUT) }.not_to raise_error
+      expect(building1.reload.bbl).to be_nil
+      expect(building2.reload.bbl).to eq bbl2[:address][:bbl]
+    end
+  end
+
+end

--- a/spec/tasks/scrub_data_for_buildings_and_users_spec.rb
+++ b/spec/tasks/scrub_data_for_buildings_and_users_spec.rb
@@ -3,17 +3,23 @@ require 'spec_helper'
 describe ScrubDataForBuildingsAndUsers do
   describe "address_scrubber" do
     it "standardizes common abbreviations" do
-      address = "North Broadway Avenue"
-      scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
+      address_one = "North Something Avenue"
+      address_two = "N Something Place"
+      address_three = "N Something Road"
+      scrubbed_one = ScrubDataForBuildingsAndUsers.address_scrubber(address_one)
+      scrubbed_two = ScrubDataForBuildingsAndUsers.address_scrubber(address_two)
+      scrubbed_three = ScrubDataForBuildingsAndUsers.address_scrubber(address_three)
 
-      expect(scrubbed).to eq("N Broadway Ave")
+      expect(scrubbed_one).to eq("N Something Ave")
+      expect(scrubbed_two).to eq("N Something Pl")
+      expect(scrubbed_three).to eq("N Something Rd")
     end
 
     it "normalizes whitespace" do
-      address = " 33  N   Broadway     Ave  "
+      address = " 33  N   Something     Ave  "
       scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
 
-      expect(scrubbed).to eq("33 N Broadway Ave")
+      expect(scrubbed).to eq("33 N Something Ave")
     end
 
     it "ordinalizes numbered streets" do
@@ -24,10 +30,101 @@ describe ScrubDataForBuildingsAndUsers do
     end
 
     it "capitalizes words" do
-      address = "12 broadway st"
+      address = "12 something st"
       scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
 
-      expect(scrubbed).to eq("12 Broadway St")
+      expect(scrubbed).to eq("12 Something St")
+    end
+
+    it "removes zip codes" do
+      address_one = "12 something st 11238"
+      address_two = "12 something st, 11238"
+      scrubbed_one = ScrubDataForBuildingsAndUsers.address_scrubber(address_one)
+      scrubbed_two = ScrubDataForBuildingsAndUsers.address_scrubber(address_two)
+
+      expect(scrubbed_one).to eq("12 Something St")
+      expect(scrubbed_two).to eq("12 Something St")
+    end
+
+    it "removes NY or New York plus city from the end" do
+      address_one = "12 something st, new york, New York"
+      address_two = "12 something st, brooklyn, NY"
+
+      scrubbed_one = ScrubDataForBuildingsAndUsers.address_scrubber(address_one)
+      scrubbed_two = ScrubDataForBuildingsAndUsers.address_scrubber(address_two)
+
+      expect(scrubbed_one).to eq("12 Something St")
+      expect(scrubbed_two).to eq("12 Something St")
+    end
+
+    it "removes PA or Pennsylvania plus city from the end" do
+      address_one = "1500 something St, Philadelphia, Pennsylvania"
+      address_two = "1500 something St, Philadelphia, Pa"
+
+      scrubbed_one = ScrubDataForBuildingsAndUsers.address_scrubber(address_one)
+      scrubbed_two = ScrubDataForBuildingsAndUsers.address_scrubber(address_two)
+
+      expect(scrubbed_one).to eq("1500 Something St")
+      expect(scrubbed_two).to eq("1500 Something St")
+    end
+
+    it "deals with apartments" do
+      address_one = "12 something st, apt. B7, new york, ny"
+      scrubbed_one = ScrubDataForBuildingsAndUsers.address_scrubber(address_one)
+      expect(scrubbed_one).to eq("12 Something St, Apt B7")
+
+      address_two = "12 something st apt. B7 new york, ny"
+      scrubbed_two = ScrubDataForBuildingsAndUsers.address_scrubber(address_two)
+      expect(scrubbed_two).to eq("12 Something St, Apt B7")
+
+      address_three = "12 something st apt B7 new york, ny"
+      scrubbed_three = ScrubDataForBuildingsAndUsers.address_scrubber(address_three)
+      expect(scrubbed_three).to eq("12 Something St, Apt B7")
+    end
+
+    it "deals with suites" do
+      address = "107-09 95th Ave Suite 103rd"
+      scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
+
+      expect(scrubbed).to eq("107-09 95th Ave, Suite 103rd")
+    end
+
+    it "deals with floors" do
+      address = "123 Something Street 3rd Floor"
+      scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
+
+      expect(scrubbed).to eq("123 Something St, 3rd Floor")
+    end
+
+    it "deals with units that have a hash before the number" do
+      address = "260 Something #2"
+      address_two = "260 Something, #2"
+      scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
+      scrubbed_two = ScrubDataForBuildingsAndUsers.address_scrubber(address_two)
+
+      expect(scrubbed).to eq("260 Something, #2")
+      expect(scrubbed_two).to eq("260 Something, #2")
+    end
+
+    it "removes city and state from suite address" do
+      address = "103-04 79th Avenue Suite 105th Corona, Ny 11368"
+      scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
+
+      expect(scrubbed).to eq("103-04 79th Ave, Suite 105th")
+    end
+
+    it "removes city and state and zip from floor address" do
+      address = "12345 Something Street 7th Floor New York, Ny 11368"
+      scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
+
+      expect(scrubbed).to eq("12345 Something St, 7th Floor")
+    end
+
+    it "removes city and state from apartment address" do
+      address = "88 Something St., Apt 2nd Brooklyn New York"
+      scrubbed = ScrubDataForBuildingsAndUsers.address_scrubber(address)
+
+      expect(scrubbed).to eq("88 Something St, Apt 2nd")
     end
   end
 end


### PR DESCRIPTION
- Add rake task that backfills BBL data on pre-existing buildings
  - `rake data:backfill_bbl`
  - GEOCLIENT_APP_ID and GEOCLIENT_APP_KEY are required
- Enhance data scrubber
  - Removing states and cities if the state is New York or Pennsylvania
  - Adds commas before apartment numbers, suites, floors, and units (`#`)
  - Removes zip codes
