### PR TITLE
disable updating sensors with sensor_codes_string

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ActiveRecord::Base
 
   validates :first_name, :length => { minimum: 2 }
   validates :last_name, :length => { minimum: 2 }
-  validate :sensor_codes_string_contains_only_valid_sensors
+  #validate :sensor_codes_string_contains_only_valid_sensors
   validates_presence_of :address, :email, :zip_code
   validates_format_of :zip_code,
                       with: /\A\d{5}-\d{4}|\A\d{5}\z/,
@@ -26,7 +26,7 @@ class User < ActiveRecord::Base
                       allow_blank: true
 
   before_save :create_search_names
-  before_validation :associate_sensors
+  # before_validation :associate_sensors
 
   before_destroy :destroy_all_collaborations
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -60,11 +60,6 @@
         <% end %>
 
         <dl>
-          <label for="user_sensor_codes_string">Sensor code</label> <i class="label-tip">(tenants only)</i>
-          <%= f.text_field :sensor_codes_string, class: "form-control" %>
-        </dl>
-
-        <dl>
           <%= f.label :current_password %> <i class="label-tip">(required to confirm changes)</i>
           <%= f.password_field :current_password, class: "form-control" %>
         </dl>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -19,9 +19,6 @@
     <dl><%= f.label :zip_code %>:
     <%= f.text_field :zip_code, class: "form-control" %></dl>
 
-    <dl><label for="user_sensor_codes_string">Sensor code</label>:
-    <%= f.text_field :sensor_codes_string, class: "form-control" %></dl>
-
     <dl><%= f.label :email %>:
     <%= f.email_field :email, class: "form-control" %></dl>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -49,11 +49,6 @@
         </dl>
 
         <dl>
-          <%= f.label :sensor_codes_string, "Sensor Code" %>:
-          <%= f.text_field :sensor_codes_string, class: "form-control short-field" %>
-        </dl>
-
-        <dl>
           <%= f.label :password %>:
           <%= f.password_field :password, class: "form-control" %>
         </dl>

--- a/spec/features/sensor_code_spec.rb
+++ b/spec/features/sensor_code_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 feature "Sensor Codes" do
 
   scenario "creating a new user account with a sensor code" do
+    pending
+
     sensor = create(:sensor, name: 'abcdefghijklmnop', nick_name: '3E4T')
 
     visit '/users/sign_up'
@@ -25,6 +27,8 @@ feature "Sensor Codes" do
   end
 
   scenario "editing an old user account to change a sensor code" do
+    pending
+
     sensor = create(:sensor, name: 'abcdefghijklmnop', nick_name: '3E4T')
     user = create(:user, password: 'password')
     login_as(user)
@@ -41,6 +45,8 @@ feature "Sensor Codes" do
   end
 
   scenario "typing an invalid sensor returns a validation error" do
+    pending
+
     user = create(:user, password: 'password')
     login_as(user)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -138,6 +138,8 @@ describe User, :vcr do
 
   describe "sensor_codes_string" do
     it "allows user save if corresponding sensors exist" do
+      pending
+
       create(:sensor, nick_name: '0000')
       user = create(:user)
       user.sensor_codes_string = '0000'
@@ -145,6 +147,8 @@ describe User, :vcr do
     end
 
     it "prevents user save if no corresponding sensors exist" do
+      pending
+
       user = create(:user)
       user.sensor_codes_string = '0000'
       expect(user.save).to be_false


### PR DESCRIPTION
`sensor_codes_string` is flawed:

- it does not check if other users have the sensor associated with them already
- it does not update when you remove the sensor association
- it's unnecessary anyway, because we already have a db assocation

I'm just disabling this for now, and will remove `sensor_codes_string` and provide a different way to associate sensors in a future PR.