### PR TITLE
Update Sensors Not Reporting Page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,6 +453,7 @@ GEM
     zip (2.0.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/app/controllers/sensors_controller.rb
+++ b/app/controllers/sensors_controller.rb
@@ -70,6 +70,7 @@ class SensorsController < ApplicationController
     @sensors = Sensor.joins(:user)
                 .joins(:readings)
                 .group("sensors.id")
+                .where("users.id = readings.user_id")
                 .select("sensors.*, MAX(readings.created_at) AS last_reading_date")
                 .having("MAX(readings.created_at) > ?", 6.months.ago)
                 .having("MAX(readings.created_at) <= ?", 6.hours.ago)

--- a/app/views/sensors/not_reporting.html.erb
+++ b/app/views/sensors/not_reporting.html.erb
@@ -10,7 +10,7 @@
         <ul>
           <li>Have not reported in the past 6 hours</li>
           <li>Has reported at least once in the past 6 months</li>
-          <li>Have an associated user</li>
+          <li>While associated with the current user</li>
         </ul>
       </div>
     </div>

--- a/spec/features/sensors_not_reporting_spec.rb
+++ b/spec/features/sensors_not_reporting_spec.rb
@@ -13,6 +13,8 @@ describe "sensors not reporting spec", type: :feature do
     create_sensor("A006", 7.months.ago)
 
     create_sensor("A007", 1.month.ago).update(user: nil)
+    create_sensor("A008", 3.months.ago)
+    reassign_sensor("A008")
 
     visit not_reporting_sensors_path
   end
@@ -34,9 +36,21 @@ describe "sensors not reporting spec", type: :feature do
     expect(page).to_not have_text "A007"
   end
 
+  it "excludes readings not associated with its current owner user" do
+    expect(page).to_not have_text "A008"
+  end
+
   def create_sensor(nick_name, time)
-    sensor = FactoryBot.create(:sensor, :with_user, nick_name: nick_name)
-    sensor.readings << FactoryBot.create(:reading, created_at: time)
+    user = FactoryBot.create(:user)
+    sensor = FactoryBot.create(:sensor, :with_user, nick_name: nick_name, user: user)
+    sensor.readings << FactoryBot.create(:reading, created_at: time, user: user)
+    sensor
+  end
+
+  def reassign_sensor(nick_name)
+    sensor = Sensor.find_by(nick_name: nick_name)
+    user = FactoryBot.create(:user)
+    sensor.update(user: user)
     sensor
   end
 end


### PR DESCRIPTION
Updates to the sensors not reporting page, and query altered to not return reassigned sensors in the "not responding" list.

1 feature spec added to capture this use case. 

https://www.pivotaltracker.com/story/show/182958655